### PR TITLE
Fix issue with names of aggregate Expressions throwing errors when spaces/special characters

### DIFF
--- a/src/UXClient/Components/Legend/Legend.ts
+++ b/src/UXClient/Components/Legend/Legend.ts
@@ -68,7 +68,7 @@ class Legend extends Component {
             .append("div") 
             .merge(seriesLabels)
             .attr("class", (d, i) => {
-                return "seriesLabel " + "seriesLabel" + d + (chartComponentData.displayState[d]["visible"] ? " shown" : "");
+                return "seriesLabel " + (chartComponentData.displayState[d]["visible"] ? " shown" : "");
             })
             .style("border-color", function (d, i) {
                 if (d3.select(this).classed("shown"))
@@ -157,7 +157,10 @@ class Legend extends Component {
                 splitByLabelData[0].push(chartComponentData.displayState[aggKey].name);
 
             /******************** Series Name Label ***********************/
-            var seriesNameLabel: any = legend.select('.seriesLabel' + aggKey)
+            var seriesNameLabel: any = legend.selectAll('.seriesLabel')
+                .filter((d) => {
+                    return (d == aggKey);
+                })
                 .selectAll('.seriesNameLabel')
                 .data([aggKey]);
             var enteredSeriesNameLabel = seriesNameLabel
@@ -211,7 +214,8 @@ class Legend extends Component {
                 }
             }
 
-            var aggs = legend.select('.seriesLabel' + aggKey)
+            var aggs = legend.select('.seriesLabel')
+                .filter(d => d == aggKey)
             .selectAll('.seriesNameLabel').selectAll("select").selectAll('option');
 
             var aggregateTypeSelection: any = enteredSeriesNameLabel
@@ -252,7 +256,8 @@ class Legend extends Component {
 
             /******************** Split By Labels *************************/
 
-            var splitByLabels: any = legend.select('.seriesLabel' + aggKey)
+            var splitByLabels: any = legend.selectAll('.seriesLabel')
+                .filter(d => d == aggKey)
                 .selectAll(".splitByLabel")
                 .data(splitByLabelData);
             splitByLabels = splitByLabels                    

--- a/src/UXClient/Components/LineChart/LineChart.ts
+++ b/src/UXClient/Components/LineChart/LineChart.ts
@@ -481,9 +481,7 @@ class LineChart extends ChartComponent {
                     }, 0);
         
                     var yMap = {};
-                    
                     var visibleAggI = 0;
-
                     this.svgSelection.selectAll(".yAxis").remove();
 
                     this.data.forEach((agg, i) => {
@@ -535,13 +533,14 @@ class LineChart extends ChartComponent {
         
                         yMap[aggKey] = aggY;
                         
-                        var yAxis: any = g.selectAll(".yAxis" + aggKey)
-                                        .data([aggY]);
+                        var yAxis: any = g.selectAll(".yAxis")
+                                .filter((yAggKey) => { return yAggKey == aggKey})
+                                        .data([aggKey]);
                         var visibleYAxis = (aggVisible && (this.yAxisState != "shared" || visibleAggI == 0));
                         
                         yAxis = yAxis.enter()
                             .append("g")
-                            .attr("class", "yAxis yAxis" + aggKey)
+                            .attr("class", "yAxis")
                             .merge(yAxis)
                             .style("visibility", ((visibleYAxis && !this.chartOptions.yAxisHidden) ? "visible" : "hidden"));
                         if (this.yAxisState == "overlap" && visibleAggCount > 1) {
@@ -767,7 +766,10 @@ class LineChart extends ChartComponent {
                                 .selectAll("text")
                                 .style("fill-opacity", .5)
                                 .classed("standardYAxisText", true);
-                            this.svgSelection.select(".yAxis" +  d.aggregateKey)
+                            this.svgSelection.selectAll(".yAxis")
+                            .filter((yAxisAggKey) => {
+                                return yAxisAggKey == d.aggregateKey; 
+                            })
                                 .selectAll("text")
                                 .style("fill-opacity", 1)
                                 .classed("standardYAxisText", false)


### PR DESCRIPTION
removed selection by class name and added filters for yAxis in line chart and legend