### PR TITLE
T7 bug bash1903

### DIFF
--- a/src/UXClient/Components/ModelSearch/ModelSearch.ts
+++ b/src/UXClient/Components/ModelSearch/ModelSearch.ts
@@ -112,7 +112,10 @@ class ModelSearch extends Component{
                                 self.closeContextMenu();
                                 if(self.clickedInstance != elt){
                                     self.clickedInstance = elt;
-                                    i.type = self.types.filter(t => t.name === i.highlights.type.split('<hit>').join('').split('</hit>').join(''))[0];
+
+                                    i.type = self.types.filter(t => {
+                                        return t.name.replace(/\s/g, '') === i.highlights.type.split('<hit>').join('').split('</hit>').join('');
+                                    })[0];
                                     let contextMenuActions = self.chartOptions.onInstanceClick(i);
                                     self.contextMenu = self.wrapper.append('div');
                                     if(!Array.isArray(contextMenuActions)){

--- a/src/UXClient/UXClient.ts
+++ b/src/UXClient/UXClient.ts
@@ -283,7 +283,8 @@ class UXClient {
                 flattenedResults.push(event); 
             });
         });
-        return flattenedResults.sort((a,b) => (new Date(a['timestamp ($ts)'])).valueOf() < (new Date(b['timestamp ($ts)_DateTime'])).valueOf() ? -1 : 1);
+        debugger;
+        return flattenedResults.sort((a,b) => (new Date(a['timestamp ($ts)'])).valueOf() < (new Date(b['timestamp ($ts)'])).valueOf() ? -1 : 1);
     }
 }
 

--- a/src/UXClient/UXClient.ts
+++ b/src/UXClient/UXClient.ts
@@ -283,7 +283,6 @@ class UXClient {
                 flattenedResults.push(event); 
             });
         });
-        debugger;
         return flattenedResults.sort((a,b) => (new Date(a['timestamp ($ts)'])).valueOf() < (new Date(b['timestamp ($ts)'])).valueOf() ? -1 : 1);
     }
 }


### PR DESCRIPTION
Legend items are now keyed by value rather than by index, which fixes an issue in T7 with subsequent renders of the legend after the available split bys change. Also, stripped whitespace for type matching because "highlights" type already has whitespace stripped 