### PR TITLE
Tutorial Dependency Paths

### DIFF
--- a/pages/samples/index.html
+++ b/pages/samples/index.html
@@ -9,14 +9,14 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/bluebird/3.3.4/bluebird.min.js"></script>    
     
     <!-- PROD RESOURCE LINKS -->
-    <!-- <link rel="stylesheet" type="text/css" href="sampleStyles.css"></link>
+    <!-- <link rel="stylesheet" type="text/css" href="./sampleStyles.css">
     <script src="https://unpkg.com/tsiclient@1.1.4/tsiclient.js"></script>
-    <link rel="stylesheet" type="text/css" href="https://unpkg.com/tsiclient@1.1.4/tsiclient.css"></link> -->
+    <link rel="stylesheet" type="text/css" href="https://unpkg.com/tsiclient@1.1.4/tsiclient.css"> -->
 
     <!-- DEV RESOURCE LINKS -->
-    <link rel="stylesheet" type="text/css" href="pages/samples/sampleStyles.css"></link>
-    <script src="dist/tsiclient.js"></script>
-    <link rel="stylesheet" type="text/css" href="dist/tsiclient.css"></link>
+    <link rel="stylesheet" type="text/css" href="./sampleStyles.css">
+    <script src="../../dist/tsiclient.js"></script>
+    <link rel="stylesheet" type="text/css" href="../../dist/tsiclient.css">
 </head>
 <body>
     <div id="loginModal" style="display: none">
@@ -50,7 +50,7 @@
                 <div class="card" style="flex-shrink: 1; height: 100%; width: 45%;">
                     <div class="cardTitle">Factory 3 Temp, Split by Station ID
                         <!-- URL parameters enables creating views programatically in the TSI explorer -->
-                        <a style="margin: 0 40px;" target="_blank" href=https://insights.timeseries.azure.com/samples?environmentId=10000000-0000-0000-0000-100000000108&from=1492261200000&to=1492264800000&timeBucketUnit=Minutes&timeBucketSize=2&timeSeriesDefinitions=[{%22name%22:%22Factory3Temp%22,%22splitBy%22:%22Station%22,%22measureName%22:%22Temperature%22,%22predicate%22:%22%27Factory3%27%22}]>View in TSI Explorer</a>
+                        <a style="margin: 0 40px;" target="_blank" href="https://insights.timeseries.azure.com/samples?environmentId=10000000-0000-0000-0000-100000000108&from=1492261200000&to=1492264800000&timeBucketUnit=Minutes&timeBucketSize=2&timeSeriesDefinitions=[{%22name%22:%22Factory3Temp%22,%22splitBy%22:%22Station%22,%22measureName%22:%22Temperature%22,%22predicate%22:%22%27Factory3%27%22}]">View in TSI Explorer</a>
                     </div>
                     <div class="cardChart" id="chart2"></div>
                 </div>
@@ -147,7 +147,7 @@
         // START: AUTHENTICATION RELATED CODE USING ADAL.JS
             // Set up ADAL
             var authContext = new AuthenticationContext({
-                clientId: '120d688d-1518-4cf7-bd38-182f158850b6',
+                clientId: '000000-000000-000000-000000',
                 postLogoutRedirectUri: 'https://insights.timeseries.azure.com',
                 cacheLocation: 'localStorage'
             });

--- a/pages/samples/index2.html
+++ b/pages/samples/index2.html
@@ -10,14 +10,14 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/bluebird/3.3.4/bluebird.min.js"></script>    
     
     <!-- PROD RESOURCE LINKS -->
-    <!-- <link rel="stylesheet" type="text/css" href="sampleStyles.css"></link>
+    <!-- <link rel="stylesheet" type="text/css" href="./sampleStyles.css">
     <script src="https://unpkg.com/tsiclient@1.1.4/tsiclient.js"></script>
-    <link rel="stylesheet" type="text/css" href="https://unpkg.com/tsiclient@1.1.4/tsiclient.css"></link> -->
+    <link rel="stylesheet" type="text/css" href="https://unpkg.com/tsiclient@1.1.4/tsiclient.css"> -->
 
     <!-- DEV RESOURCE LINKS -->
-    <link rel="stylesheet" type="text/css" href="pages/samples/sampleStyles.css"></link>
-    <script src="dist/tsiclient.js"></script>
-    <link rel="stylesheet" type="text/css" href="dist/tsiclient.css"></link>
+    <link rel="stylesheet" type="text/css" href="./sampleStyles.css">
+    <script src="../../dist/tsiclient.js"></script>
+    <link rel="stylesheet" type="text/css" href="../../dist/tsiclient.css">
 </head>
 <body>
     <div id="loginModal" style="display: none">
@@ -58,7 +58,7 @@
         // START: AUTHENTICATION RELATED CODE USING ADAL.JS
             // Set up ADAL
             var authContext = new AuthenticationContext({
-                clientId: '120d688d-1518-4cf7-bd38-182f158850b6',
+                clientId: '000000-000000-000000-000000',
                 postLogoutRedirectUri: 'https://insights.timeseries.azure.com',
                 cacheLocation: 'localStorage'
             });

--- a/pages/tutorial/index.html
+++ b/pages/tutorial/index.html
@@ -9,15 +9,14 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/bluebird/3.3.4/bluebird.min.js"></script>    
     
     <!-- PROD RESOURCE LINKS -->
-    <!-- <link rel="stylesheet" type="text/css" href="sampleStyles.css"></link>
+    <!-- <link rel="stylesheet" type="text/css" href="./sampleStyles.css">
     <script src="https://unpkg.com/tsiclient@1.1.4/tsiclient.js"></script>
-    <link rel="stylesheet" type="text/css" href="https://unpkg.com/tsiclient@1.1.4/tsiclient.css"></link> -->
+    <link rel="stylesheet" type="text/css" href="https://unpkg.com/tsiclient@1.1.4/tsiclient.css"> -->
 
     <!-- DEV RESOURCE LINKS -->
-    <link rel="stylesheet" type="text/css" href="pages/samples/sampleStyles.css"></link>
-    <script src="dist/tsiclient.js"></script>
-    <link rel="stylesheet" type="text/css" href="dist/tsiclient.css"></link>
-</head>
+    <link rel="stylesheet" type="text/css" href="./sampleStyles.css">
+    <script src="../../dist/tsiclient.js"></script>
+    <link rel="stylesheet" type="text/css" href="../../dist/tsiclient.css">
 <body>
     <div id="loginModal" style="display: none">
         <div>
@@ -50,7 +49,7 @@
                 <div class="card" style="flex-shrink: 1; height: 100%; width: 45%;">
                     <div class="cardTitle">Factory 3 Temp, Split by Station ID
                         <!-- URL parameters enables creating views programatically in the TSI explorer -->
-                        <a style="margin: 0 40px;" target="_blank" href=https://insights.timeseries.azure.com/samples?environmentId=10000000-0000-0000-0000-100000000108&from=1492261200000&to=1492264800000&timeBucketUnit=Minutes&timeBucketSize=2&timeSeriesDefinitions=[{%22name%22:%22Factory3Temp%22,%22splitBy%22:%22Station%22,%22measureName%22:%22Temperature%22,%22predicate%22:%22%27Factory3%27%22}]>View in TSI Explorer</a>
+                        <a style="margin: 0 40px;" target="_blank" href="https://insights.timeseries.azure.com/samples?environmentId=10000000-0000-0000-0000-100000000108&from=1492261200000&to=1492264800000&timeBucketUnit=Minutes&timeBucketSize=2&timeSeriesDefinitions=[{%22name%22:%22Factory3Temp%22,%22splitBy%22:%22Station%22,%22measureName%22:%22Temperature%22,%22predicate%22:%22%27Factory3%27%22}]">View in TSI Explorer</a>
                     </div>
                     <div class="cardChart" id="chart2"></div>
                 </div>
@@ -147,8 +146,8 @@
         // START: AUTHENTICATION RELATED CODE USING ADAL.JS
             // Set up ADAL
             var authContext = new AuthenticationContext({
-                clientId: '120d688d-1518-4cf7-bd38-182f158850b6',
-                postLogoutRedirectUri: 'https://insights.timeseries.azure.com',
+                clientId: '000000-000000-000000-000000',
+                postLogoutRedirectUri: 'https://tsiapp.azurewebsites.net/',
                 cacheLocation: 'localStorage'
             });
             

--- a/pages/windApp/sampleStyles.css
+++ b/pages/windApp/sampleStyles.css
@@ -1,0 +1,117 @@
+body{ 
+	font-family: "Segoe UI", sans-serif; 
+	background: #3d4147; 
+	height: 100%; 
+	padding: 0; 
+	margin: 0;
+} 
+
+#loginModal{
+	position: fixed;
+	z-index: 3;
+	background: rgba(0,0,0,.3);
+	height: 100%;
+	width: 100%;
+	top: 0;
+}
+
+#loginModal > div{
+	padding: 20px;
+	margin: auto;
+	position: absolute;
+	left: 0;
+	right: 0;
+	top: -20%;
+	bottom: 0;
+	width: 400px;
+    height: 200px;
+    background: #111;
+    text-align: center;
+	box-shadow: 0px 0px 2px 2px rgba(255,255,255,.1);
+	color: white;
+}
+
+#loginModal > div > span{
+	display: block;
+	margin: 40px;
+	margin-bottom: 60px;
+	font-size: 20px;
+}
+
+#loginModal > div > a{
+	font-size: 18px;
+	text-decoration: none;
+	padding: 8px 12px;
+	border: 1px solid white;
+}
+.rowOfCards{
+	width: 100%; 
+	flex-grow: 1; 
+	display: flex; 
+	justify-content: space-around; 
+	height: 500px; 
+	padding-bottom: 40px;
+	margin-bottom: 4px;
+	border-bottom: 1px solid silver;
+} 
+.rowOfCardsTitle{
+	width: 100%;
+	color: white;
+	padding: 16px 0 20px;
+	text-align: center;
+}
+.card{
+	border: 1px solid silver; 
+} 
+.cardTitle{
+	height: 24px; 
+	border-bottom: 1px solid silver; 
+	padding: 4px; 
+	color: white;
+	text-align: center;
+} 
+.cardChart{
+	height: calc(100% - 33px); 
+	width: 100%;
+}
+.header{ 
+	z-index: 2; 
+	background: black; 
+	position: fixed; 
+	top: 0; 
+	left: 0; 
+	height: 24px; 
+	padding: 8px; 
+	border-bottom: 1px solid #888; 
+	width: 100%; 
+	color: white; 
+} 
+#api_response2{ 
+	position: absolute; 
+	left: 250px; 
+	top: -8px; 
+	border-left: 1px solid #888; 
+	padding: 8px 16px; 
+	white-space: normal; 
+	height: 12px; 
+} 
+.rightSide{ 
+	position: absolute; 
+	top: 0; 
+	right: 0; 
+	margin-right: 40px; 
+} 
+.loginLogout{ 
+	position: absolute; 
+	top: 6px; 
+	font-size: 13px; 
+	right: 0; 
+} 
+a{ 
+	color: white; 
+}
+.chartsWrapper{
+	height: calc(100% - 40px); 
+	margin-top: 40px;
+	width: 100%;
+}

--- a/pages/windApp/windApp.html
+++ b/pages/windApp/windApp.html
@@ -8,7 +8,6 @@
     <link rel="stylesheet" href="https://atlas.microsoft.com/sdk/css/atlas.min.css?api-version=1.0" type="text/css" />
     <script src="https://atlas.microsoft.com/sdk/js/atlas.min.js?api-version=1.0"></script>
 
-
     <script src="https://secure.aadcdn.microsoftonline-p.com/lib/1.0.11/js/adal.min.js"></script>
     
     <!--bluebird for Promise polyfill to support IE in sample client-->
@@ -16,18 +15,17 @@
 
     <!-- PROD RESOURCE LINKS -->
     <!-- <script src="windApp.js" defer></script>
-    <link rel="stylesheet" type="text/css" href="sampleStyles.css"></link>
-    <link rel="stylesheet" type="text/css" href="windApp.css"></link>
+    <link rel="stylesheet" type="text/css" href="./sampleStyles.css">
+    <link rel="stylesheet" type="text/css" href="./windApp.css">
     <script src="https://unpkg.com/tsiclient@1.1.4/tsiclient.js"></script>
-    <link rel="stylesheet" type="text/css" href="https://unpkg.com/tsiclient@1.1.4/tsiclient.css"></link> -->
-
+    <link rel="stylesheet" type="text/css" href="https://unpkg.com/tsiclient@1.1.4/tsiclient.css"> -->
 
     <!-- DEV RESOURCE LINKS -->
     <script src="pages/windApp/windApp.js" defer></script>	
-    <link rel="stylesheet" type="text/css" href="pages/samples/sampleStyles.css"></link>	
-    <link rel="stylesheet" type="text/css" href="pages/windApp/windApp.css"></link>	
-    <script src="dist/tsiclient.js"></script>
-    <link rel="stylesheet" type="text/css" href="dist/tsiclient.css"></link>
+    <link rel="stylesheet" type="text/css" href="./sampleStyles.css">
+    <link rel="stylesheet" type="text/css" href="./windApp.css">	
+    <script src="../../dist/tsiclient.js"></script>
+    <link rel="stylesheet" type="text/css" href="../../dist/tsiclient.css">
     
 </head>
 <body>
@@ -111,7 +109,7 @@
         // START: AUTHENTICATION RELATED CODE USING ADAL.JS
             // Set up ADAL
             var authContext = new AuthenticationContext({
-                clientId: 'b54d43ab-4c7d-41cc-bea4-f39016158011',
+                clientId: '000000-000000-000000-000000',
                 postLogoutRedirectUri: 'https://tsiclientsample.azurewebsites.net',
                 cacheLocation: 'localStorage'
             });


### PR DESCRIPTION
Hi! I've created a PR to improve some of the [Tutorial documentation](https://docs.microsoft.com/azure/time-series-insights/tutorial-create-tsi-sample-spa) and examples (which live in the `tutorial` branch independently of `master`) . An Issue was created [Issue #29347](https://github.com/MicrosoftDocs/azure-docs/issues/29347) to address changes to this repo (and branch) along with the documentation.

Specifically, this PR makes the following changes:

1. This corrects the default dependency file paths of the `tutorial` branch HTML files (including the example used in the article).
1. It moves the `sampleStyles.css` into the `windApp.html` directory (which was done in the other couple examples).
1. Corrected `link` tags (should not have closing tag) and added quotes to urls.

The `tutorial` branch also has the following warning: 

>DO NOT change any file names/locations unless corresponding changes are made to the docs articles and/or publishing config file (.openpublishing.publish.config.json). Just changing a file name/location can cause all OPS builds to fail!

Thank you!