### PR TITLE
Less dense instance search results and improved search experience

### DIFF
--- a/src/UXClient/Components/ModelAutocomplete/ModelAutocomplete.ts
+++ b/src/UXClient/Components/ModelAutocomplete/ModelAutocomplete.ts
@@ -41,6 +41,7 @@ class ModelAutocomplete extends Component{
             if(d3.event.which === 13 || d3.event.keyCode === 13){
                 noSuggest = true;
                 self.ap.close();
+                self.chartOptions.onInput(searchText, d3.event);
             }
         });
 
@@ -56,7 +57,7 @@ class ModelAutocomplete extends Component{
                 })
             }
             noSuggest = false;
-            self.chartOptions.onInput(searchText);
+            self.chartOptions.onInput(searchText, d3.event);
             clear.classed('tsi-shown', searchText.length);
         })
     }

--- a/src/UXClient/Components/ModelSearch/ModelSearch.ts
+++ b/src/UXClient/Components/ModelSearch/ModelSearch.ts
@@ -125,7 +125,7 @@ class ModelSearch extends Component{
                                     self.clickedInstance = elt;
 
                                     i.type = self.types.filter(t => {
-                                        return t.name.replace(/\s/g, '') === i.highlights.type.split('<hit>').join('').split('</hit>').join('');
+                                        return t.name.replace(/\s/g, '') === (i.highlights.type ? i.highlights.type.split('<hit>').join('').split('</hit>').join('') : i.highlights.typeName.split('<hit>').join('').split('</hit>').join(''));
                                     })[0];
                                     let contextMenuActions = self.chartOptions.onInstanceClick(i);
                                     self.contextMenu = self.wrapper.append('div');
@@ -242,12 +242,12 @@ class ModelSearch extends Component{
     private getInstanceHtml(i) {
         return `<div class="tsi-modelResult">
                     <div class="tsi-modelPK">
-                        ${i.highlights.name ? this.stripHits(i.highlights.name) : this.stripHits(i.highlights.timeSeriesIds.join(' '))}
+                        ${i.highlights.name ? this.stripHits(i.highlights.name) : this.stripHits(i.highlights.timeSeriesIds ? i.highlights.timeSeriesIds.join(' ') : i.highlights.timeSeriesId.join(' '))}
                     </div>
                     <div class="tsi-modelHighlights">
                         ${this.stripHits(i.highlights.description && i.highlights.description.length ? i.highlights.description : 'No description')}
                         <br/><table>
-                        ${i.highlights.name ? ('<tr><td>Time Series ID</td><td>' + this.stripHits(i.highlights.timeSeriesIds.join(' ')) + '</td></tr>') : ''}                        
+                        ${i.highlights.name ? ('<tr><td>Time Series ID</td><td>' + this.stripHits(i.highlights.timeSeriesIds ? i.highlights.timeSeriesIds.join(' ') : i.highlights.timeSeriesId.join(' ')) + '</td></tr>') : ''}                        
                         ${i.highlights.instanceFieldNames.map((ifn, idx) => {
                             var val = i.highlights.instanceFieldValues[idx];
                             if (ifn.indexOf('<hit>') !== -1 || val.indexOf('<hit>') !== -1) {

--- a/src/UXClient/Components/ModelSearch/ModelSearch.ts
+++ b/src/UXClient/Components/ModelSearch/ModelSearch.ts
@@ -45,7 +45,7 @@ class ModelSearch extends Component{
         let inputWrapper = this.wrapper.append("div")
             .attr("class", "tsi-modelSearchInputWrapper");
 
-        let autocompleteOnInput = (st) => {
+        let autocompleteOnInput = (st, event) => {
             self.usedContinuationTokens = {};
 
             // blow results away if no text
@@ -57,14 +57,14 @@ class ModelSearch extends Component{
                 (showMore.node() as any).style.display = 'none';
                 noResults.style('display', 'none');
             }
-            else {
+            else if (event.which === 13 || event.keyCode === 13) {
                 (hierarchyElement.node() as any).style.display = 'none';
                 self.instanceResults.html('');
                 self.currentResultIndex = -1;
                 noResults.style('display', 'none');
                 searchInstances(st);
                 searchText = st;
-            } 
+            }  
         }
 
         let modelAutocomplete = new ModelAutocomplete(inputWrapper.node());
@@ -250,7 +250,9 @@ class ModelSearch extends Component{
                         ${i.highlights.name ? ('<tr><td>Time Series ID</td><td>' + this.stripHits(i.highlights.timeSeriesIds.join(' ')) + '</td></tr>') : ''}                        
                         ${i.highlights.instanceFieldNames.map((ifn, idx) => {
                             var val = i.highlights.instanceFieldValues[idx];
-                            return val.length === 0 ? '' :  '<tr><td>' + this.stripHits(ifn) + '</td><td>' + this.stripHits(i.highlights.instanceFieldValues[idx]) + '</tr>';
+                            if (ifn.indexOf('<hit>') !== -1 || val.indexOf('<hit>') !== -1) {
+                                return val.length === 0 ? '' :  '<tr><td>' + this.stripHits(ifn) + '</td><td>' + this.stripHits(val) + '</tr>';
+                            }
                         }).join('')}
                         </table>
                     </div>


### PR DESCRIPTION
Showing only instance fields with hits in search results and and get search results when enter key is pressed to prevent confusion about consistency between suggestions and search results.