### PR TITLE
IsTemporal Option & CR Changes

### DIFF
--- a/docs/UX.md
+++ b/docs/UX.md
@@ -58,11 +58,11 @@ var scatterPlot = new tsiClient.ux.ScatterPlot(document.getElementById('chart'))
 scatterPlot.render(data, chartOptions, chartDataOptionsArray);
 ```
 
-The following code snippet shows an example of the scatter plot specific chart options: [spMeasures](#chart-options) & [isTemporal](#chart-options).  The first string in the spMeasures array is the X axis measure.  The second string is the Y axis measure, and the third (optional) string is the data point radius measure.  The isTemporal chartOption defaults to **true** if not set, but can be set to **false** as shown below.   
+The following code snippet shows an example of the scatter plot specific chart options: [spMeasures](#chart-options) & [isTemporal](#chart-options).  The first string in the spMeasures array is the X axis measure.  The second string is the Y axis measure, and the third (optional) string is the data point radius measure.  The isTemporal chartOption defaults to **false** if not set, but can be set to **true** as shown below.   
 
 ```js
-scatterPlot.render(data, {spMeasures:['temp', 'press', 'vol'], isTemporal: false});
-/*                                   ^ X     ^ Y      ^ R (optional)       ^ Turn off temporal slider */
+scatterPlot.render(data, {spMeasures:['temp', 'press', 'vol'], isTemporal: true});
+/*                                   ^ X     ^ Y      ^ R (optional)       ^ Turn on temporal slider */
 ```
 
 *Scatter Plot will not render if spMeasures is not specified or **any** of the measures are not found in the [data](#chart-data-shape) as value keys*
@@ -227,7 +227,7 @@ The most common available parameters for chart options are as follows (bold opti
 |noAnimate|boolean|**false**,true|If true, uppresses animated chart transitions|
 |offset|any|**0**, -120, 'America/Los_Angeles'|Offset for all timestamps in minutes from UTC, or a timezone supported by moment.js|
 |spMeasures| any| Array&lt;string&gt; | X, Y, and Radius (optional) measures passed into Scatter Plot |
-|isTemporal| boolean| **true** | **true**: scatter plot has temporal slider to slide through time slices **false**: scatter plot renders all timestamps.
+|isTemporal| boolean| **false** | **true**: scatter plot has temporal slider to slide through time slices **false**: scatter plot renders all timestamps.
 |stacked|boolean|**false**|If true, stack bars in barchart|
 |states|Array<any>|**null**, Array&lt;[State](#line-chart-events-and-states-data-shape)&gt;|An array of time range bound states passed into the linechart|
 |theme|string|**'dark'**, 'light'|Component color scheme|

--- a/docs/UX.md
+++ b/docs/UX.md
@@ -50,7 +50,7 @@ heatmap.render(data, chartOptions, chartDataOptionsArray);
 
 ### Scatter Plot
 
-Scatter plots are created in the same way as the line chart, and they take the same options and data shapes.  For Scatter plots however, [spMeasures](#chart-options) must be specified as an array of strings in the chartOptions object.  
+Scatter plots are created in the same way as the line chart, and they take the same options and data shapes.  For Scatter plots however, [spMeasures](#chart-options) **must** be specified as an array of strings in the chartOptions object, [isTemporal](#chart-options) is an additional chartOption which toggles the temporal slider.  
 
 ```js
 var tsiClient = new TsiClient();
@@ -58,11 +58,11 @@ var scatterPlot = new tsiClient.ux.ScatterPlot(document.getElementById('chart'))
 scatterPlot.render(data, chartOptions, chartDataOptionsArray);
 ```
 
-The following code snippet shows an example of the [spMeasures](#chart-options) chartOption.  The first string in the spMeasures array is the X axis measure.  The second string is the Y axis measure, and the third (optional) string is the data point radius measure.   
+The following code snippet shows an example of the scatter plot specific chart options: [spMeasures](#chart-options) & [isTemporal](#chart-options).  The first string in the spMeasures array is the X axis measure.  The second string is the Y axis measure, and the third (optional) string is the data point radius measure.  The isTemporal chartOption defaults to **true** if not set, but can be set to **false** as shown below.   
 
 ```js
-scatterPlot.render(data, {spMeasures:['temp', 'press', 'vol']});
-/*                                   ^ X     ^ Y      ^ R (optional) */
+scatterPlot.render(data, {spMeasures:['temp', 'press', 'vol'], isTemporal: false});
+/*                                   ^ X     ^ Y      ^ R (optional)       ^ Turn off temporal slider */
 ```
 
 *Scatter Plot will not render if spMeasures is not specified or **any** of the measures are not found in the [data](#chart-data-shape) as value keys*
@@ -227,6 +227,7 @@ The most common available parameters for chart options are as follows (bold opti
 |noAnimate|boolean|**false**,true|If true, uppresses animated chart transitions|
 |offset|any|**0**, -120, 'America/Los_Angeles'|Offset for all timestamps in minutes from UTC, or a timezone supported by moment.js|
 |spMeasures| any| Array&lt;string&gt; | X, Y, and Radius (optional) measures passed into Scatter Plot |
+|isTemporal| boolean| **true** | **true**: scatter plot has temporal slider to slide through time slices **false**: scatter plot renders all timestamps.
 |stacked|boolean|**false**|If true, stack bars in barchart|
 |states|Array<any>|**null**, Array&lt;[State](#line-chart-events-and-states-data-shape)&gt;|An array of time range bound states passed into the linechart|
 |theme|string|**'dark'**, 'light'|Component color scheme|

--- a/pages/examples/noauth/chartOptions.html
+++ b/pages/examples/noauth/chartOptions.html
@@ -179,6 +179,15 @@
                         <option>.1</option> 
                     </select>
                 </div>
+
+                <h3>Chart options - SP specific</h3>
+                <div>
+                    <label>isTemporal </label>
+                    <select onchange='(function(){ toggleChartOption("isTemporal", (event.target.value === "true")) })(event)'>
+                            <option value='true' selected>true</option>
+                            <option value='false'>false</option>
+                    </select>
+                </div>
             </div>
             <div style="width: calc(100% - 320px);">
                 <div id="linechart" style="width: 100%; height: 400px; margin-bottom:20px;"></div>
@@ -219,7 +228,8 @@
                 stacked: false, 
                 zeroYAxis: true,
                 arcWidthRatio: 1,
-                spMeasures: ['avg', 'min', 'max']
+                spMeasures: ['avg', 'min', 'max'],
+                isTemporal: true
             }
             var scatterPlot;
             var lineChart;

--- a/pages/examples/noauth/scatterPlot.html
+++ b/pages/examples/noauth/scatterPlot.html
@@ -12,7 +12,7 @@
         <div id="temporalToggle" class = "buttonWrapper" style= "display: none;align-items: center; justify-content: center;"><button onclick="toggleTemporal()">Toggle Temporal</button></div>
 
         <script>
-            let temporal = true;
+            let temporal = false;
             let toggleTemporal = null;
             window.onload = function() {
                 // Show toggle

--- a/pages/examples/noauth/scatterPlot.html
+++ b/pages/examples/noauth/scatterPlot.html
@@ -26,7 +26,7 @@
                         for(var j = 0; j < 5; j++){
                             var values = {};
                             lines[`Station${j}`] = values;
-                            for(var k = 0; k < 500; k++){
+                            for(var k = 0; k < 100; k++){
                                 if(!(k%2 && k%3)){  // if check is to create some sparseness in the data
                                     var to = new Date(from.valueOf() + 1000*k);
                                     var val = Math.random() * scaleFactor;
@@ -48,10 +48,10 @@
                 var tsiClient = new TsiClient();
 
                 var scatterPlot1 =  new tsiClient.ux.ScatterPlot(document.getElementById('chart1'));
-                scatterPlot1.render(getData(), {grid: true, tooltip: true, theme: 'light', spMeasures: ['temp', 'press', 'vol'], scatterPlot1});
-                setTimeout(() => {
-                    scatterPlot1.render(getData(Math.random() * 10), {grid: true, tooltip: true, theme: 'light', spMeasures: ['temp', 'press', 'vol'], scatterPlot1});
-                }, 5000)
+                scatterPlot1.render(getData(), {isTemporal: true, grid: true, tooltip: true, theme: 'light', spMeasures: ['temp', 'press', 'vol'], scatterPlot1});
+                // setTimeout(() => {
+                //     scatterPlot1.render(getData(Math.random() * 10), {grid: true, tooltip: true, theme: 'light', spMeasures: ['temp', 'press', 'vol'], scatterPlot1});
+                // }, 5000)
             };
         </script>
     </body>

--- a/pages/examples/noauth/scatterPlot.html
+++ b/pages/examples/noauth/scatterPlot.html
@@ -9,29 +9,32 @@
     </head>
     <body style="font-family: 'Segoe UI', sans-serif;">
         <div id="chart1" style="width: 100%; height: 600px;"></div>
-        <div id="chart2" style="width: 100%; height: 600px;"></div>
+        <div id="temporalToggle" class = "buttonWrapper" style= "display: none;align-items: center; justify-content: center;"><button onclick="toggleTemporal()">Toggle Temporal</button></div>
 
         <script>
+            let temporal = true;
+            let toggleTemporal = null;
             window.onload = function() {
+                // Show toggle
+                document.getElementById("temporalToggle").style.display = "flex";
                 // create fake data in the shape our charts expect
-
-                var iteration = 0;
-                var getData = (scaleFactor = 1) => {
-                    var data = [];
-                    var from = new Date(Math.floor((new Date()).valueOf() / (1000*60)) * (1000*60) + iteration*1000*60);
-                    var to;
-                    for(var i = 0; i < 3; i++){
-                        var lines = {};
+                let iteration = 0;
+                let getData = (scaleFactor = 1) => {
+                    let data = [];
+                    let from = new Date(Math.floor((new Date()).valueOf() / (1000*60)) * (1000*60) + iteration*1000*60);
+                    let to;
+                    for(let i = 0; i < 3; i++){
+                        let lines = {};
                         data.push({[`Factory${i}`]: lines});
-                        for(var j = 0; j < 5; j++){
-                            var values = {};
+                        for(let j = 0; j < 5; j++){
+                            let values = {};
                             lines[`Station${j}`] = values;
-                            for(var k = 0; k < 100; k++){
+                            for(let k = 0; k < 100; k++){
                                 if(!(k%2 && k%3)){  // if check is to create some sparseness in the data
-                                    var to = new Date(from.valueOf() + 1000*k);
-                                    var val = Math.random() * scaleFactor;
-                                    var val2 = Math.random() * scaleFactor;
-                                    var val3 = Math.random() * scaleFactor;
+                                    let to = new Date(from.valueOf() + 1000*k);
+                                    let val = Math.random() * scaleFactor;
+                                    let val2 = Math.random() * scaleFactor;
+                                    let val3 = Math.random() * scaleFactor;
                                     values[to.toISOString()] = {press: val, temp: val2, vol: val3};
                                 }
                             }
@@ -43,16 +46,24 @@
                     return data;
                 }
 
+                let getRandomBoolean = () => Math.random() > 0.5 ? true : false;
 
                 // render the data in a chart
-                var tsiClient = new TsiClient();
+                let tsiClient = new TsiClient();
+                let data = getData();
 
-                var scatterPlot1 =  new tsiClient.ux.ScatterPlot(document.getElementById('chart1'));
-                scatterPlot1.render(getData(), {isTemporal: true, grid: true, tooltip: true, theme: 'light', spMeasures: ['temp', 'press', 'vol'], scatterPlot1});
-                // setTimeout(() => {
-                //     scatterPlot1.render(getData(Math.random() * 10), {grid: true, tooltip: true, theme: 'light', spMeasures: ['temp', 'press', 'vol'], scatterPlot1});
-                // }, 5000)
+                let scatterPlot =  new tsiClient.ux.ScatterPlot(document.getElementById('chart1'));
+
+                let renderScatterPlot = () => scatterPlot.render(data, {isTemporal: temporal, grid: true, tooltip: true, theme: 'light', spMeasures: ['temp', 'press', 'vol'], scatterPlot});
+
+                renderScatterPlot();
+
+                toggleTemporal = () => {
+                    temporal = !temporal;
+                    renderScatterPlot();
+                }
             };
+            
         </script>
     </body>
 </html>

--- a/src/UXClient/Components/ScatterPlot/ScatterPlot.scss
+++ b/src/UXClient/Components/ScatterPlot/ScatterPlot.scss
@@ -49,9 +49,8 @@
         height: 55px;
         bottom: 8px;
         right: 0px;
-        width: 100%;
     }
-
+    
     .tsi-scatterPlotSVG{
         .xAxis, .yAxis text{
             font-size: 12px;

--- a/src/UXClient/Components/ScatterPlot/ScatterPlot.ts
+++ b/src/UXClient/Components/ScatterPlot/ScatterPlot.ts
@@ -25,9 +25,9 @@ class ScatterPlot extends ChartComponent {
     private rMeasure: string;
     private rScale: any;
     private slider: any;
+    private slideWrapper: any;
     private svgSelection: any;
     private targetElement: any;
-    private timestamp: any;
     private tooltip: Tooltip;
     private voronoi: any;
     private voronoiDiagram: any;
@@ -96,7 +96,7 @@ class ScatterPlot extends ChartComponent {
                 .classed("tsi-pointWrapper", true);
 
             // Create temporal slider div
-            d3.select(this.renderTarget).append('div').classed('tsi-sliderWrapper', true);
+            this.slideWrapper = d3.select(this.renderTarget).append('div').classed('tsi-sliderWrapper', true);
                 
             this.tooltip = new Tooltip(d3.select(this.renderTarget));
 
@@ -158,8 +158,6 @@ class ScatterPlot extends ChartComponent {
                 .attr("x", -10)
                 .text((d: string) => d);
 
-            this.legendObject = new Legend(this.draw.bind(this), this.renderTarget, this.CONTROLSWIDTH);
-
             // Add Window Resize Listener
             window.addEventListener("resize", () => {
                 if (!this.chartOptions.suppressResizeListener) {
@@ -169,6 +167,9 @@ class ScatterPlot extends ChartComponent {
 
             // Temporal slider
             this.slider = new Slider(<any>d3.select(this.renderTarget).select('.tsi-sliderWrapper').node());
+
+            // Legend
+            this.legendObject = new Legend(this.draw.bind(this), this.renderTarget, this.CONTROLSWIDTH);
         }
 
         // Draw scatter plot
@@ -281,12 +282,15 @@ class ScatterPlot extends ChartComponent {
 
         scatter.exit().remove();
         
-        // Draw Legend
-        this.legendObject.draw(this.chartOptions.legend, this.chartComponentData, this.labelMouseOver.bind(this), 
-            this.svgSelection, this.chartOptions, this.labelMouseOut.bind(this), this.stickySeries);
-        
         // Draw voronoi
         this.drawVoronoi();
+
+        // Resize controls
+        if (!this.chartOptions.hideChartControlPanel && this.chartControlsPanel !== null) {
+            let controlPanelWidth = Utils.getControlPanelWidth(this.renderTarget, this.CONTROLSWIDTH, this.chartOptions.legend === 'shown');
+            this.chartControlsPanel.style("width", controlPanelWidth + "px");
+        }
+
 
         /******************** Temporal Slider ************************/
         if(this.chartComponentData.allTimestampsArray.length > 1){
@@ -303,6 +307,13 @@ class ScatterPlot extends ChartComponent {
             this.slider.remove();
             d3.select(this.renderTarget).select('.tsi-sliderWrapper').classed('tsi-hidden', true);
         }
+
+        // Draw Legend
+        this.legendObject.draw(this.chartOptions.legend, this.chartComponentData, this.labelMouseOver.bind(this), 
+            this.svgSelection, this.chartOptions, this.labelMouseOut.bind(this), this.stickySeries);
+
+        this.slideWrapper
+            .style("width", `${this.svgSelection.node().getBoundingClientRect().width + 10}px`);
     }
 
     /******** CHECK VALIDITY OF EXTENTS ********/

--- a/src/UXClient/Components/ScatterPlot/ScatterPlot.ts
+++ b/src/UXClient/Components/ScatterPlot/ScatterPlot.ts
@@ -24,7 +24,7 @@ class ScatterPlot extends ChartComponent {
     private rMeasure: string;
     private rScale: any;
     private slider: any;
-    private slideWrapper: any;
+    private sliderWrapper: any;
     private svgSelection: any;
     private targetElement: any;
     private tooltip: Tooltip;
@@ -95,7 +95,7 @@ class ScatterPlot extends ChartComponent {
                 .classed("tsi-pointWrapper", true);
 
             // Create temporal slider div
-            this.slideWrapper = d3.select(this.renderTarget).append('div').classed('tsi-sliderWrapper', true);
+            this.sliderWrapper = d3.select(this.renderTarget).append('div').classed('tsi-sliderWrapper', true);
                 
             this.tooltip = new Tooltip(d3.select(this.renderTarget));
 
@@ -312,7 +312,7 @@ class ScatterPlot extends ChartComponent {
         this.legendObject.draw(this.chartOptions.legend, this.chartComponentData, this.labelMouseOver.bind(this), 
             this.svgSelection, this.chartOptions, this.labelMouseOut.bind(this), this.stickySeries);
 
-        this.slideWrapper
+        this.sliderWrapper
             .style("width", `${this.svgSelection.node().getBoundingClientRect().width + 10}px`);
     }
 

--- a/src/UXClient/Components/ScatterPlot/ScatterPlot.ts
+++ b/src/UXClient/Components/ScatterPlot/ScatterPlot.ts
@@ -12,7 +12,6 @@ class ScatterPlot extends ChartComponent {
     private activeDot: any = null;
     private chartHeight: number;
     private chartWidth: number;
-    private colorMap: any = {};
     private controlsOffset: number;
     private focus: any;
     private focusedAggKey: string;
@@ -231,9 +230,6 @@ class ScatterPlot extends ChartComponent {
         // Pad extents
         let xOffset = (20 / this.chartWidth) * (this.chartComponentData.extents[this.xMeasure][1] - this.chartComponentData.extents[this.xMeasure][0]);
         let yOffset = (20 / this.chartHeight) * (this.chartComponentData.extents[this.yMeasure][1] - this.chartComponentData.extents[this.yMeasure][0]);
-        
-        // Create color scale for each aggregate key
-        this.initColorScale();
 
         // Check measure validity
         if(!this.checkExtentValidity()) return;
@@ -274,8 +270,8 @@ class ScatterPlot extends ChartComponent {
             .attr("r", (d) => this.rScale(d.measures[this.rMeasure]))
             .attr("cx", (d) => this.xScale(d.measures[this.xMeasure]))
             .attr("cy", (d) => this.yScale(d.measures[this.yMeasure]))
-            .attr("fill", (d) => this.colorMap[d.aggregateKey](d.splitBy))
-            .attr("stroke", (d) => this.colorMap[d.aggregateKey](d.splitBy))
+            .attr("fill", (d) => Utils.colorSplitBy(this.chartComponentData.displayState, d.splitByI, d.aggregateKey, this.chartOptions.keepSplitByColor))
+            .attr("stroke", (d) => Utils.colorSplitBy(this.chartComponentData.displayState, d.splitByI, d.aggregateKey, this.chartOptions.keepSplitByColor))
             .attr("stroke-opacity", 1)
             .attr("fill-opacity", .6)
             .attr("stroke-width", "1px")
@@ -440,7 +436,7 @@ class ScatterPlot extends ChartComponent {
     private unhighlightDot(){
         if(this.activeDot != null){
         this.activeDot
-                .attr("stroke", (d) => this.colorMap[d.aggregateKey](d.splitBy))
+                .attr("stroke", (d) => Utils.colorSplitBy(this.chartComponentData.displayState, d.splitByI, d.aggregateKey, this.chartOptions.keepSplitByColor))
                 .attr("stroke-width", "1px")
         }
         this.activeDot = null;
@@ -606,21 +602,9 @@ class ScatterPlot extends ChartComponent {
             .interrupt()
             .attr("stroke-opacity", 1)
             .attr("fill-opacity", .6)
-            .attr("stroke", (d) => this.colorMap[d.aggregateKey](d.splitBy))
-            .attr("fill", (d) => this.colorMap[d.aggregateKey](d.splitBy))
+            .attr("stroke", (d) => Utils.colorSplitBy(this.chartComponentData.displayState, d.splitByI, d.aggregateKey, this.chartOptions.keepSplitByColor))
+            .attr("fill", (d) => Utils.colorSplitBy(this.chartComponentData.displayState, d.splitByI, d.aggregateKey, this.chartOptions.keepSplitByColor))
             .attr("stroke-width", "1px");
-    }
-
-
-
-    /******** CREATE COLOR SCALE FOR EACH AGGREGATE, SPLITBY ********/
-    private initColorScale(){
-        this.chartComponentData.data.forEach((d) => {
-            let colors = Utils.createSplitByColors(this.chartComponentData.displayState, d.aggKey, this.chartOptions.keepSplitByColor);
-            this.colorMap[d.aggKey] = d3.scaleOrdinal()
-                .domain(this.chartComponentData.displayState[d.aggKey].splitBys)
-                .range(colors);
-        });
     }
 
     /******** FILTER DATA, ONLY KEEPING POINTS WITH ALL REQUIRED MEASURES ********/

--- a/src/UXClient/Components/ScatterPlot/ScatterPlot.ts
+++ b/src/UXClient/Components/ScatterPlot/ScatterPlot.ts
@@ -675,10 +675,12 @@ class ScatterPlot extends ChartComponent {
                     .text(d.splitBy);
 
                 let valueGroup = text.append('div').classed('valueGroup', true);
-                Object.keys(d.measures).forEach((measureType, i) => {
-                    valueGroup.append("div")
+                Object.keys(d.measures).forEach((measureType) => {
+                    if(measureType in this.chartComponentData.extents){
+                        valueGroup.append("div")
                         .attr("class",  "value")
                         .text(measureType + ": " + Utils.formatYAxisNumber(d.measures[measureType]));
+                    }
                 });
             });
         }

--- a/src/UXClient/Components/ScatterPlot/ScatterPlot.ts
+++ b/src/UXClient/Components/ScatterPlot/ScatterPlot.ts
@@ -189,8 +189,13 @@ class ScatterPlot extends ChartComponent {
         this.focus.attr("visibility", (this.chartOptions.focusHidden) ? "hidden" : "visible")
 
         // Determine the number of timestamps present, add margin for slider
-        if(this.chartComponentData.allTimestampsArray.length > 1 && this.chartOptions.isTemporal)
+        if(this.chartComponentData.allTimestampsArray.length > 1 && this.chartOptions.isTemporal){
             this.chartMargins.bottom = 88;
+        }
+        else{
+            this.chartMargins.bottom = 48;
+        }
+           
 
         this.setWidthAndHeight();
         this.svgSelection

--- a/src/UXClient/Components/ScatterPlot/ScatterPlot.ts
+++ b/src/UXClient/Components/ScatterPlot/ScatterPlot.ts
@@ -165,8 +165,7 @@ class ScatterPlot extends ChartComponent {
             });
 
             // Temporal slider
-            if(this.chartOptions.isTemporal)
-                this.slider = new Slider(<any>d3.select(this.renderTarget).select('.tsi-sliderWrapper').node());
+            this.slider = new Slider(<any>d3.select(this.renderTarget).select('.tsi-sliderWrapper').node());
 
             // Legend
             this.legendObject = new Legend(this.draw.bind(this), this.renderTarget, this.CONTROLSWIDTH);
@@ -196,7 +195,6 @@ class ScatterPlot extends ChartComponent {
             this.chartMargins.bottom = 48;
         }
            
-
         this.setWidthAndHeight();
         this.svgSelection
             .attr("height", this.height)
@@ -293,7 +291,6 @@ class ScatterPlot extends ChartComponent {
             this.chartControlsPanel.style("width", controlPanelWidth + "px");
         }
 
-
         /******************** Temporal Slider ************************/
         if(this.chartComponentData.allTimestampsArray.length > 1 && this.chartOptions.isTemporal){
             d3.select(this.renderTarget).select('.tsi-sliderWrapper').classed('tsi-hidden', false);
@@ -306,7 +303,8 @@ class ScatterPlot extends ChartComponent {
             }), this.chartOptions, this.width - 10,  Utils.timeFormat(this.chartComponentData.usesSeconds, this.chartComponentData.usesMillis, this.chartOptions.offset, this.chartOptions.is24HourTime)(new Date(this.chartComponentData.timestamp)));
         }
         else{
-            this.slider.remove();
+            if(this.slider)
+                this.slider.remove();
             d3.select(this.renderTarget).select('.tsi-sliderWrapper').classed('tsi-hidden', true);
         }
 
@@ -699,6 +697,7 @@ class ScatterPlot extends ChartComponent {
         }
     }
 
+    /******** HELPERS TO FORMAT TIME DISPLAY ********/
     private labelFormatUsesSeconds () {
         return !this.chartOptions.minutesForTimeLabels && this.chartComponentData.usesSeconds;
     }

--- a/src/UXClient/Components/Slider/Slider.ts
+++ b/src/UXClient/Components/Slider/Slider.ts
@@ -135,6 +135,7 @@ class Slider extends Component{
         if(this.sliderSVG)
             this.sliderSVG.remove();
         this.sliderSVG = null;
+        this.sliderTextDiv.remove();
     }
 
     private onDrag (h) {

--- a/src/UXClient/Components/Slider/Slider.ts
+++ b/src/UXClient/Components/Slider/Slider.ts
@@ -135,7 +135,8 @@ class Slider extends Component{
         if(this.sliderSVG)
             this.sliderSVG.remove();
         this.sliderSVG = null;
-        this.sliderTextDiv.remove();
+        if(this.sliderTextDiv)
+            this.sliderTextDiv.remove();
     }
 
     private onDrag (h) {

--- a/src/UXClient/Models/ChartOptions.ts
+++ b/src/UXClient/Models/ChartOptions.ts
@@ -26,6 +26,7 @@ class ChartOptions {
     public interpolationFunction: any; //which interpolation function used for line chart lines
     public isArea: boolean; // whether lines in LineChart are also areas
     public isCompact: boolean; // whether availability chart is in compact or expanded mode
+    public isTemporal: boolean; // whether scatter plot has temporal slider
     public is24HourTime: boolean; // whether time is displayed in 24, or 12 hour time with am/pm
     public keepBrush: boolean; // whether to keep the brush selected region upon re render
     public keepSplitByColor: boolean; //whether to keep the split By colors when state is updated
@@ -149,7 +150,8 @@ class ChartOptions {
         this.markers = Utils.getValueOrDefault(chartOptionsObj, 'markers', null); // intentionally not mergeValue
         this.onMarkersChange = this.mergeValue(chartOptionsObj, 'onMarkersChange', (markers) => {});
         this.spMeasures = this.mergeValue(chartOptionsObj, 'spMeasures', null);
-        this.scatterPlotRadius = this.mergeValue(chartOptionsObj, 'scatterPlotRadius', [4,10])
+        this.scatterPlotRadius = this.mergeValue(chartOptionsObj, 'scatterPlotRadius', [4,10]);
+        this.isTemporal = this.mergeValue(chartOptionsObj, "isTemporal", true);
         this.xAxisTimeFormat = this.mergeValue(chartOptionsObj, 'xAxisTimeFormat', null);
     }
 

--- a/src/UXClient/Models/ChartOptions.ts
+++ b/src/UXClient/Models/ChartOptions.ts
@@ -151,7 +151,7 @@ class ChartOptions {
         this.onMarkersChange = this.mergeValue(chartOptionsObj, 'onMarkersChange', (markers) => {});
         this.spMeasures = this.mergeValue(chartOptionsObj, 'spMeasures', null);
         this.scatterPlotRadius = this.mergeValue(chartOptionsObj, 'scatterPlotRadius', [4,10]);
-        this.isTemporal = this.mergeValue(chartOptionsObj, "isTemporal", true);
+        this.isTemporal = this.mergeValue(chartOptionsObj, "isTemporal", false);
         this.xAxisTimeFormat = this.mergeValue(chartOptionsObj, 'xAxisTimeFormat', null);
     }
 

--- a/src/UXClient/Models/ScatterPlotData.ts
+++ b/src/UXClient/Models/ScatterPlotData.ts
@@ -1,6 +1,7 @@
 import {ChartComponentData} from "./ChartComponentData";
 import { GroupedBarChartData } from "./GroupedBarChartData";
 import * as d3 from "d3";
+import { Utils } from "../Utils";
 
 class ScatterPlotData extends GroupedBarChartData {
     public temporalDataArray: any;
@@ -28,26 +29,81 @@ class ScatterPlotData extends GroupedBarChartData {
     public mergeDataToDisplayStateAndTimeArrays (data, timestamp, aggregateExpressionOptions = null, events = null, states = null ) {
         ChartComponentData.prototype.mergeDataToDisplayStateAndTimeArrays.call(this, data, aggregateExpressionOptions, events, states);
         this.timestamp = (timestamp != undefined && this.allTimestampsArray.indexOf(timestamp) !== -1) ? timestamp : this.allTimestampsArray[0];
-        super.setValuesAtTimestamp();
+        this.setValuesAtTimestamp();
         this.setAllTimestampsArray();
     }
 
-    public updateTemporalDataArray () {
-        let dataArray = []
-        Object.keys(this.valuesAtTimestamp).forEach((aggKey) => {
-            Object.keys(this.valuesAtTimestamp[aggKey].splitBys).forEach((splitBy, splitByI) => {
-                let measures = null;
-                if (this.getSplitByVisible(aggKey, splitBy) && this.valuesAtTimestamp[aggKey].splitBys[splitBy].measurements != undefined)
-                    measures = this.valuesAtTimestamp[aggKey].splitBys[splitBy].measurements;
-                dataArray.push({
-                    aggregateKey: aggKey,
-                    splitBy: splitBy,
-                    measures,
-                    splitByI: splitByI
+    public updateTemporalDataArray (isTemporal: boolean) {
+        if(!isTemporal){
+            let dataArray = []
+            this.allTimestampsArray.forEach((ts) => {
+                this.timestamp = ts;
+                this.setValuesAtTimestamp();
+                Object.keys(this.valuesAtTimestamp).forEach((aggKey) => {
+                    Object.keys(this.valuesAtTimestamp[aggKey].splitBys).forEach((splitBy, splitByI) => {
+                        let measures = null, timestamp = null;
+                        if (this.getSplitByVisible(aggKey, splitBy) && this.valuesAtTimestamp[aggKey].splitBys[splitBy].measurements != undefined){
+                            measures = this.valuesAtTimestamp[aggKey].splitBys[splitBy].measurements; 
+                            timestamp = this.valuesAtTimestamp[aggKey].splitBys[splitBy].timestamp; 
+                        }   
+                            
+                        dataArray.push({
+                            aggregateKey: aggKey,
+                            splitBy: splitBy,
+                            measures,
+                            timestamp,
+                            splitByI: splitByI
+                        });
+                    });
                 });
             });
+            
+            this.temporalDataArray = dataArray;
+        } else{
+            let dataArray = []
+            Object.keys(this.valuesAtTimestamp).forEach((aggKey) => {
+                Object.keys(this.valuesAtTimestamp[aggKey].splitBys).forEach((splitBy, splitByI) => {
+                    let measures = null, timestamp = null;
+                    if (this.getSplitByVisible(aggKey, splitBy) && this.valuesAtTimestamp[aggKey].splitBys[splitBy].measurements != undefined){
+                        measures = this.valuesAtTimestamp[aggKey].splitBys[splitBy].measurements; 
+                        timestamp = this.valuesAtTimestamp[aggKey].splitBys[splitBy].timestamp; 
+                    }   
+                        
+                    dataArray.push({
+                        aggregateKey: aggKey,
+                        splitBy: splitBy,
+                        measures,
+                        timestamp,
+                        splitByI: splitByI
+                    });
+                });
+            });
+            this.temporalDataArray = dataArray;
+        }
+    }
+
+    public setValuesAtTimestamp () {
+        var aggregateCounterMap = {};
+        this.valuesAtTimestamp = {};
+        this.data.forEach((aggregate, aggI) => {
+            var aggName: string = Object.keys(aggregate)[0];
+            var aggKey;
+            if (aggregateCounterMap[aggName]) {
+                aggKey = Utils.createEntityKey(aggName, aggregateCounterMap[aggName]);
+                aggregateCounterMap[aggName] += 1;
+            } else {
+                aggKey = Utils.createEntityKey(aggName, 0);
+                aggregateCounterMap[aggName] = 1;
+            }
+            this.valuesAtTimestamp[aggKey] = {};
+            this.valuesAtTimestamp[aggKey].splitBys = Object.keys(aggregate[aggName])
+                                                .reduce((aggSplitBys: any, splitBy: string, splitByI: number) => {
+                aggSplitBys[splitBy] = {};
+                aggSplitBys[splitBy].measurements = aggregate[aggName][splitBy][this.timestamp];
+                aggSplitBys[splitBy].timestamp = this.timestamp;
+                return aggSplitBys;
+            }, {});
         });
-        this.temporalDataArray = dataArray;
     }
 }
 export {ScatterPlotData}

--- a/src/UXClient/Models/ScatterPlotData.ts
+++ b/src/UXClient/Models/ScatterPlotData.ts
@@ -6,7 +6,7 @@ import { Utils } from "../Utils";
 class ScatterPlotData extends GroupedBarChartData {
     public temporalDataArray: any;
     public extents: any = {};
-    private extentsSet: boolean = false 
+    private extentsSet: boolean = false; 
 
 	constructor(){
         super();


### PR DESCRIPTION
## Changes
- Added isTemporal chart option to allow toggle between temporal slider display mode and all timestamp display mode
- Updated docs with isTemporal option
- Updated scatter plot HTML test with isTemporal toggle
- Added correct bottom margin toggle for temporal slider showing / hidden
- Added scatterPlotData model comments for clarity 
## Bug Fixes
- Fixed full-width slider overlapping legend and blocking clicks on lowest legend item
- Fixed color mapping problem where legend colors did not correlate with scatter plot colors
- Fixed tool-tip measure display where all measures were shown -- tool-tip now only displays relevant measures

## isTemoral Model
To toggle between temporal and all timestamp data, the isTemporal chartOption is used.  
### Non-temporal
In non-temporal mode, all timestamps are iterated over, the values fetched at that timestamp, and the data at that timestamp pushed to the flattened temporalDataArray.  This allows for both temporal / non-temporal modes to render the same data shape minimizing logic changes.
### Temporal
In temporal mode, the timestamp is set via the temporal slider, and the temporalDataArray is updated in the scatterPlotData model with all values matching the current timestamp. 

*The code below shows the logic behind the temporal model -- updateTemporal pushes all data at the current timestamp to the temporalDataArray which is used to render the scatter plot data*

```
if(!isTemporal){
    this.allTimestampsArray.forEach((ts) => {
        this.timestamp = ts;
        this.setValuesAtTimestamp();
        this.updateTemporal();
    });          
} else{
    this.updateTemporal();
}
    
```


