### PR TITLE
fixed head tag

### DIFF
--- a/pages/tutorial/index.html
+++ b/pages/tutorial/index.html
@@ -17,6 +17,7 @@
     <link rel="stylesheet" type="text/css" href="./sampleStyles.css">
     <script src="../../dist/tsiclient.js"></script>
     <link rel="stylesheet" type="text/css" href="../../dist/tsiclient.css">
+</head>
 <body>
     <div id="loginModal" style="display: none">
         <div>


### PR DESCRIPTION
This fixes the unintentional removal of the closing `head` tag from: https://github.com/microsoft/tsiclient/pull/83 which corrected some paths and link tags for the https://docs.microsoft.com/azure/time-series-insights/tutorial-create-tsi-sample-spa document.

Browsers will throw a warning when loading the HTML but it will still render fine. Lost my head there. My fault, thanks!