### PR TITLE
Docs cleanup for130

### DIFF
--- a/docs/UX.md
+++ b/docs/UX.md
@@ -14,7 +14,7 @@ lineChart.render(data, chartOptions, chartDataOptionsArray);
 
 where the parameter ``data`` follows the shape definied in [Chart Data Shape](#chart-data-shape), ``chartOptions`` contain some subset of the properties defined in [Chart Options](#chart-options), and ``chartDataOptionsArray`` is an array of objects that contain a subset of properties definied in [Chart Data Options](#chart-data-options).
 
-A line chart can hold three different types of plots - a line plot, and event plot, and a categorical plot. The type of plot for each data group is specified
+A line chart can hold three different types of plots - a line plot, an event plot, and a categorical plot. The type of plot for each data group is specified
 with the [DataType](#chart-data-options) Chart Data Option, and multiple types are possible concurrently in one line chart. An example of all three types in one chart can be 
 found in [this example](https://tsiclientsample.azurewebsites.net/noauth/multipleseriestypes.html). Special Chart Data Options are used when dataType is non-numeric: heght,
 valueMapping, and onElementClick. rollupCategoricalValues is unique to groups with datType of categorical.
@@ -274,6 +274,7 @@ The available parameters for chart data options are as follows...
 |valueMapping|[valueMapping](#value-mapping)|{}|Defines the relationship between measures and their colors in non-numeric plots in the line chart|
 |onElementClick|(dataGroupName: string, timeSeriesName: string, timestamp: string, measures: Array<any>) => void|**null**|handler for when an element in a non-numeric plot in the linechart is clicked. the paramters are: data group, series name, timestamp, and measures at that timestamp| 
 |rollupCategoricalValues|boolean|**false**|for categorical plots in line charts, this specifies that adjacent measures with the same values should be rolled into the first with those values|
+|eventElementType|string|**'diamond'**, teardrop|specifies the svg icon for an event in the line chart, either a diamond or a teardrop|
 
 ***Note**: Some parameters are present in both chart options and chart data options. For boolean values, the property will evaluate to true if either value is true. For other types of values, the chart data option value will take precendence over the chart option value.* 
 

--- a/docs/UX.md
+++ b/docs/UX.md
@@ -15,9 +15,9 @@ lineChart.render(data, chartOptions, chartDataOptionsArray);
 where the parameter ``data`` follows the shape definied in [Chart Data Shape](#chart-data-shape), ``chartOptions`` contain some subset of the properties defined in [Chart Options](#chart-options), and ``chartDataOptionsArray`` is an array of objects that contain a subset of properties definied in [Chart Data Options](#chart-data-options).
 
 A line chart can hold three different types of plots - a line plot, an event plot, and a categorical plot. The type of plot for each data group is specified
-with the [DataType](#chart-data-options) Chart Data Option, and multiple types are possible concurrently in one line chart. An example of all three types in one chart can be 
-found in [this example](https://tsiclientsample.azurewebsites.net/noauth/multipleseriestypes.html). Special Chart Data Options are used when dataType is non-numeric: heght,
-valueMapping, and onElementClick. rollupCategoricalValues is unique to groups with datType of categorical.
+with the [dataType](#chart-data-options) Chart Data Option, and multiple types are possible concurrently in one line chart. An example of all three types in one chart can be 
+found in [this example](https://tsiclientsample.azurewebsites.net/noauth/multipleseriestypes.html). Special Chart Data Options are used when dataType is non-numeric: height,
+[valueMapping](#value-mapping), and onElementClick. rollupCategoricalValues is unique to groups with datType of categorical.
 
 ### Bar Chart
 

--- a/pages/examples/noauth/multipleseriestypes.html
+++ b/pages/examples/noauth/multipleseriestypes.html
@@ -82,7 +82,7 @@
 
                 states[`Station3`] = values4;
 
-                let eventValueMapping = {
+                var eventValueMapping = {
                     badEvent: {
                         color: 'red'
                     },
@@ -91,7 +91,7 @@
                     }
                 }
 
-                let valueMapping = {
+                var valueMapping = {
                     state1: {
                         color: '#F2C80F'
                     }, 

--- a/src/UXClient/Interfaces/Plot.ts
+++ b/src/UXClient/Interfaces/Plot.ts
@@ -24,7 +24,7 @@ class Plot extends Component {
     }
 
     protected createGradientKey (d, splitByIndex, i) {
-        return unescape(d.aggregateKey).split(" ").join("_") + '_' + splitByIndex + '_' + i;
+        return d.aggregateKey.replace(/^[^a-z]+|[^\w:.-]+/gi, "") + '_' + splitByIndex + '_' + i;
     }
 
     protected addGradientStops (d, gradient) {


### PR DESCRIPTION
Docs for the new shape of line chart with events and categories and also a fix for the regex for escaping characters when creating gradient IDs