### PR TITLE
Increasing stroke width for event icon

### DIFF
--- a/src/UXClient/Components/EventsPlot/EventsPlot.ts
+++ b/src/UXClient/Components/EventsPlot/EventsPlot.ts
@@ -137,7 +137,7 @@ class EventsPlot extends Plot {
                             return 'translate(' + (self.x(new Date(d.dateTime)) + self.eventHeight / 2) + ',' + (self.eventHeight * 1.4) + ') rotate(180)';
                         })
                         .attr('d', teardropD(self.eventHeight, self.eventHeight))
-                        .attr('stroke-width', Math.min(self.eventHeight / 4, 8))
+                        .attr('stroke-width', Math.min(self.eventHeight / 2.25, 8))
                         .attr('stroke', colorFunction);
                     break;
                 case EventElementTypes.Diamond:


### PR DESCRIPTION
Increasing stroke width of tear drop event icon.

![image](https://user-images.githubusercontent.com/44848884/68634823-807fcf80-04ab-11ea-8c43-9ae343a93e18.png)
