### PR TITLE
Fixing tsconfig to match our module loading style

### DIFF
--- a/src/UXClient/Components/DateTimePicker/DateTimePicker.ts
+++ b/src/UXClient/Components/DateTimePicker/DateTimePicker.ts
@@ -331,9 +331,9 @@ class DateTimePicker extends ChartComponent{
         var i18nOptions = {
             previousMonth : this.getString('Previous Month'),
             nextMonth     : this.getString('Next Month'),
-            months        : moment.localeData()._months,
-            weekdays      : moment.localeData()._weekdays,
-            weekdaysShort : moment.localeData()._weekdaysMin
+            months        : moment.localeData().months,
+            weekdays      : moment.localeData().weekdays,
+            weekdaysShort : moment.localeData().weekdaysMin
         };
 
         this.calendarPicker = new Pikaday({ 

--- a/src/UXClient/Components/SingleDateTimePicker/SingleDateTimePicker.ts
+++ b/src/UXClient/Components/SingleDateTimePicker/SingleDateTimePicker.ts
@@ -91,9 +91,9 @@ class SingleDateTimePicker extends ChartComponent{
         var i18nOptions = {
             previousMonth : this.getString('Previous Month'),
             nextMonth     : this.getString('Next Month'),
-            months        : moment.localeData()._months,
-            weekdays      : moment.localeData()._weekdays,
-            weekdaysShort : moment.localeData()._weekdaysMin
+            months        : moment.localeData().months,
+            weekdays      : moment.localeData().weekdays,
+            weekdaysShort : moment.localeData().weekdaysMin
         };
 
         this.calendarPicker = new Pikaday({ 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
         "jsx": "react",
         "allowJs": true,
         "lib" : ["es5", "es2015.promise", "dom", "es6"],
-        "declaration": true
+        "declaration": true,
+        "moduleResolution": "Node"
     }
 }


### PR DESCRIPTION
We load modules from the node_modules/ folder, but the current tsconfig.json is not configured for this. It defaults to an older module resolution method that doesn't look for modules inside the node_module folder.
I'm also fixing some build errors that surfaced as a result of making this config change.