### PR TITLE
Fixing module resolution mode in tsconfig.json

### DIFF
--- a/src/UXClient/Components/DateTimePicker/DateTimePicker.ts
+++ b/src/UXClient/Components/DateTimePicker/DateTimePicker.ts
@@ -341,9 +341,9 @@ class DateTimePicker extends ChartComponent{
         var i18nOptions = {
             previousMonth : this.getString('Previous Month'),
             nextMonth     : this.getString('Next Month'),
-            months        : moment.localeData()._months,
-            weekdays      : moment.localeData()._weekdays,
-            weekdaysShort : moment.localeData()._weekdaysMin
+            months        : moment.localeData().months,
+            weekdays      : moment.localeData().weekdays,
+            weekdaysShort : moment.localeData().weekdaysMin
         };
 
         this.calendarPicker = new Pikaday({ 

--- a/src/UXClient/Components/SingleDateTimePicker/SingleDateTimePicker.ts
+++ b/src/UXClient/Components/SingleDateTimePicker/SingleDateTimePicker.ts
@@ -110,9 +110,9 @@ class SingleDateTimePicker extends ChartComponent{
         var i18nOptions = {
             previousMonth : this.getString('Previous Month'),
             nextMonth     : this.getString('Next Month'),
-            months        : moment.localeData()._months,
-            weekdays      : moment.localeData()._weekdays,
-            weekdaysShort : moment.localeData()._weekdaysMin
+            months        : moment.localeData().months,
+            weekdays      : moment.localeData().weekdays,
+            weekdaysShort : moment.localeData().weekdaysMin
         };
 
         this.calendarPicker = new Pikaday({ 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
         "target": "es5",
         "jsx": "react",
         "allowJs": true,
-        "lib" : ["es5", "es2015.promise", "dom", "es6"]
+        "lib" : ["es5", "es2015.promise", "dom", "es6"],
+        "moduleResolution": "Node"
     }
 }


### PR DESCRIPTION
Setting the moduleResolution flag in tsconfig to 'Node' so that typescript knows to look for dependencies in the node_modules folder. Also fixing some build errors as a result of this change.