### PR TITLE
User/niusoff/context menu improvements

### DIFF
--- a/pages/examples/testcases/nestedContextMenu.html
+++ b/pages/examples/testcases/nestedContextMenu.html
@@ -71,6 +71,41 @@
                                 console.log("sub action 2");
                                 console.log(dataGroup, timeSeriesName, timestamp)
                             }
+                        },
+                        {
+                            name: 'sub action 3',
+                            action: function (dataGroup, timeSeriesName, timestamp) {
+                                console.log("sub action 3");
+                                console.log(dataGroup, timeSeriesName, timestamp)
+                            }
+                        },
+                        {
+                            name: 'sub action 3',
+                            action: function (dataGroup, timeSeriesName, timestamp) {
+                                console.log("sub action 3");
+                                console.log(dataGroup, timeSeriesName, timestamp)
+                            }
+                        }
+                        ,{
+                            name: 'sub action 3',
+                            action: function (dataGroup, timeSeriesName, timestamp) {
+                                console.log("sub action 3");
+                                console.log(dataGroup, timeSeriesName, timestamp)
+                            }
+                        }
+                        ,{
+                            name: 'sub action 3',
+                            action: function (dataGroup, timeSeriesName, timestamp) {
+                                console.log("sub action 3");
+                                console.log(dataGroup, timeSeriesName, timestamp)
+                            }
+                        },
+                        {
+                            name: 'sub action 3',
+                            action: function (dataGroup, timeSeriesName, timestamp) {
+                                console.log("sub action 3");
+                                console.log(dataGroup, timeSeriesName, timestamp)
+                            }
                         }
 
                     ]
@@ -94,6 +129,13 @@
                             name: 'sub action 2',
                             action: function (dataGroup, timeSeriesName, timestamp) {
                                 console.log("sub action 2");
+                                console.log(dataGroup, timeSeriesName, timestamp)
+                            }
+                        },
+                        {
+                            name: 'sub action 3',
+                            action: function (dataGroup, timeSeriesName, timestamp) {
+                                console.log("sub action 3");
                                 console.log(dataGroup, timeSeriesName, timestamp)
                             }
                         }

--- a/pages/examples/testcases/nestedContextMenu.html
+++ b/pages/examples/testcases/nestedContextMenu.html
@@ -19,7 +19,7 @@
                 var data = [];
                 var from = new Date();
                 var to;
-                for(var i = 0; i < 2; clei++){
+                for(var i = 0; i < 2; i++){
                     var lines = {};
                     data.push({[`Factory${i}`]: lines});
                     for(var j = 0; j < 5; j++){
@@ -54,6 +54,51 @@
                     action: function(dataGroup, timeSeriesName, timestamp) {
                         barChart.render(data.filter(d => Object.keys(d)[0] === dataGroup.alias), {timestamp: timestamp}, [{contextMenu: genericDataContextMenu}]);
                     }
+                }, {
+                    name: 'nested actions',
+                    isNested: true,
+                    subActions: [
+                        {
+                            name: 'sub action 1',
+                            action: function (dataGroup, timeSeriesName, timestamp) {
+                                console.log("sub action 1");
+                                console.log(dataGroup, timeSeriesName, timestamp)
+                            }
+                        },
+                        {
+                            name: 'sub action 2',
+                            action: function (dataGroup, timeSeriesName, timestamp) {
+                                console.log("sub action 2");
+                                console.log(dataGroup, timeSeriesName, timestamp)
+                            }
+                        }
+
+                    ]
+                }, {
+                    name: "Plot as a Bar Chart V2",
+                    action: function(dataGroup, timeSeriesName, timestamp) {
+                        barChart.render(data.filter(d => Object.keys(d)[0] === dataGroup.alias), {timestamp: timestamp}, [{contextMenu: genericDataContextMenu}]);
+                    }
+                }, {
+                    name: 'nested actions v2',
+                    isNested: true,
+                    subActions: [
+                        {
+                            name: 'sub action 1',
+                            action: function (dataGroup, timeSeriesName, timestamp) {
+                                console.log("sub action 1");
+                                console.log(dataGroup, timeSeriesName, timestamp)
+                            }
+                        },
+                        {
+                            name: 'sub action 2',
+                            action: function (dataGroup, timeSeriesName, timestamp) {
+                                console.log("sub action 2");
+                                console.log(dataGroup, timeSeriesName, timestamp)
+                            }
+                        }
+
+                    ]
                 }];
 
                 var brushContextMenu = [{

--- a/pages/examples/testcases/nestedContextMenu.html
+++ b/pages/examples/testcases/nestedContextMenu.html
@@ -1,0 +1,80 @@
+
+<!DOCTYPE html> 
+<html>
+    <head>
+        <title>Context Menu</title>
+
+        <!-- boilerplate headers are injected with head.js, grab them from the live example header, or include a link to head.js -->
+        <script src="../boilerplate/head.js"></script>
+    </head>
+    <body style="font-family: 'Segoe UI', sans-serif; display: flex; justify-content: space-between; flex-wrap: wrap">
+        <div style="width: 100%; flex-shrink: 0; padding-bottom: 8px;">Right click on chart data or the line chart brush to use custom context menus</div>
+        <div id="chart1" style="width: 100%; height: 400px;"></div>
+        <div id="chart2" style="width: 50%; height: 300px;"></div>
+        <div id="chart3" style="width: 50%; height: 300px;"></div>
+        <script>
+            window.onload = function() {
+                
+                // create fake data in the shape our charts expect
+                var data = [];
+                var from = new Date();
+                var to;
+                for(var i = 0; i < 2; clei++){
+                    var lines = {};
+                    data.push({[`Factory${i}`]: lines});
+                    for(var j = 0; j < 5; j++){
+                        var values = {};
+                        lines[`Station${j}`] = values;
+                        for(var k = 0; k < 60; k++){
+                            if(!(k%2 && k%3)){  // if check is to create some sparseness in the data
+                                var to = new Date(from.valueOf() + 1000*60*k);
+                                values[to.toISOString().split('.')[0]+"Z"] = {avg: Math.random() * 20};
+                            }
+                        }
+                    }
+                }
+
+                var genericDataContextMenu = [{
+                    name: "Print parameters to console",
+                    action: function(dataGroup, timeSeriesName, timestamp) {
+                        console.log(dataGroup);
+                        console.log(timeSeriesName);
+                        console.log(timestamp);
+                    }
+                }]
+
+                var lineChartDataContextMenu = [...genericDataContextMenu,
+                {
+                    name: "Plot as a Pie Chart",
+                    action: function(dataGroup, timeSeriesName, timestamp) {
+                        pieChart.render(data.filter(d => Object.keys(d)[0] === dataGroup.alias), {timestamp: timestamp}, [{contextMenu: genericDataContextMenu}]);
+                    }
+                }, {
+                    name: "Plot as a Bar Chart",
+                    action: function(dataGroup, timeSeriesName, timestamp) {
+                        barChart.render(data.filter(d => Object.keys(d)[0] === dataGroup.alias), {timestamp: timestamp}, [{contextMenu: genericDataContextMenu}]);
+                    }
+                }];
+
+                var brushContextMenu = [{
+                    name: "Print parameters to console",
+                    action: function(from, to) {
+                        console.log(from);
+                        console.log(to);
+                    }
+                }]
+
+                // render the data in a chart
+                var tsiClient = new TsiClient();
+                var lineChart = new tsiClient.ux.LineChart(document.getElementById('chart1'));
+                // BUG: measureTypes must be present for sparse data
+                lineChart.render(JSON.parse(JSON.stringify(data)), {legend: 'compact', theme: 'dark', grid: true, tooltip: true, brushContextMenuActions: brushContextMenu}, 
+                    [{measureTypes: ['avg'], searchSpan: {from: from.toISOString(), to: to.toISOString(), bucketSize: '1m'}, contextMenu: lineChartDataContextMenu, alias: 'Factory0'}, {contextMenu: lineChartDataContextMenu, alias: 'Factory1'}]);
+
+                var barChart = new tsiClient.ux.BarChart(document.getElementById('chart2'));
+
+                var pieChart = new tsiClient.ux.PieChart(document.getElementById('chart3'));
+            };
+        </script>
+    </body>
+</html>

--- a/src/UXClient/Components/ContextMenu/ContextMenu.scss
+++ b/src/UXClient/Components/ContextMenu/ContextMenu.scss
@@ -1,26 +1,55 @@
 @import "../../styles";
 
+
+
 .tsi-dark{
     $grays: grays('dark');
     @include baseContextMenuColors($grays);
+    .tsi-actionElementContainer {
+        .tsi-actionElement {
+            &.tsi-hasSubMenu {
+                background: url(../../Icons/CaretClosed_Dark_Theme.svg);
+            }
+        }
+    }
 }
 .tsi-light{
     $grays: grays('light');
     @include baseContextMenuColors($grays);
+    .tsi-actionElementContainer {
+        .tsi-actionElement {
+            &.tsi-hasSubMenu {
+                background: url(../../Icons/CaretClosed_Light_Theme.svg);
+            }
+        }
+    }
 }
 
 .tsi-contextMenu {
-    @extend .tsi-baseContextMenu;
     display: none;
     position: absolute;
-    height: auto;
-    max-width: 200px;
-    z-index: 2;
+    z-index: 3;
+    .tsi-actionElementContainer {
+        @extend .tsi-baseContextMenu;
+        height: auto;
+        max-width: 200px;
+        z-index: 3;
+        overflow-y: auto;
+        display: block;
+        position: absolute;
 
-    .tsi-actionElement {
-        padding: 4px 16px;
-        cursor: default;
-        font-size: 12px;
-    }
-	
+        overflow-y: auto;
+        max-height: 240px;
+    
+        .tsi-actionElement {
+            padding: 4px 16px;
+            cursor: default;
+            font-size: 12px;
+            &.tsi-hasSubMenu {
+                background-repeat: no-repeat;
+                background-position: calc(100% - 4px), 50%;
+                background-size: 12px 12px;
+            }
+        }
+    }	
 }

--- a/src/UXClient/Components/ContextMenu/ContextMenu.scss
+++ b/src/UXClient/Components/ContextMenu/ContextMenu.scss
@@ -37,9 +37,7 @@
         overflow-y: auto;
         display: block;
         position: absolute;
-
         overflow-y: auto;
-        max-height: 240px;
     
         .tsi-actionElement {
             padding: 4px 16px;

--- a/src/UXClient/Components/LineChart/LineChart.ts
+++ b/src/UXClient/Components/LineChart/LineChart.ts
@@ -773,6 +773,10 @@ class LineChart extends TemporalXAxisComponent {
     }
 
     private voronoiClick (mouseEvent) {
+        //supress if the context menu is visible
+        if (this.contextMenu && this.contextMenu.contextMenuVisible)
+            return;
+    
         if (!this.filteredValueExist() || !this.voronoiExists()) return;
         if (this.brushElem && !this.isDroppingMarker) return;
         const [mx, my] = d3.mouse(mouseEvent);
@@ -880,7 +884,7 @@ class LineChart extends TemporalXAxisComponent {
             this.brushStartPosition = null;
             this.brushEndPosition = null;
 
-            if (!this.isDroppingMarker && !isClearingBrush) {
+            if (!this.isDroppingMarker && !isClearingBrush && !(this.contextMenu && this.contextMenu.contextMenuVisible)) {
                 this.stickySeries(site.data.aggregateKey, site.data.splitBy);
             } else {
                 this.isDroppingMarker = false;

--- a/src/UXClient/Components/LinePlot/LinePlot.ts
+++ b/src/UXClient/Components/LinePlot/LinePlot.ts
@@ -317,6 +317,7 @@ class LinePlot extends Plot {
                 path.exit().remove();
                 previousAggregateData.set(this, splitBy);
             });
+            splitByGroups.exit().remove();
     }
 }
 export {LinePlot}


### PR DESCRIPTION
Essentially a rewrite of ContextMenu

- now handles nested actions, works very well for two levels deep and works passably well beyond that - there might be overlap in actions on each level though
- handling of overflow: logic now exists to keep the context menu within the confines of its parent by flipping the context menu to the right or up as necessary.
- finally got rid of the bug where clicking out of a context menu triggers sticky/unsticky
- z index fixes