### PR TITLE
User/niusoff/startat

### DIFF
--- a/pages/examples/testcases/seriesLabels.html
+++ b/pages/examples/testcases/seriesLabels.html
@@ -43,8 +43,8 @@
 
                 let counter = 0;
                 setInterval(() => {
-                    if (counter < 6) {
-                        lineChart.render(data, {theme: 'light', tooltip: true, labelSeriesWithMarker: (counter % 2 === 0)}, [{},{timeShift: '-1m', variableAlias: 'd'}, {timeShift: '-1m', variableAlias: 'this is a prettttty long variable alias'}]);
+                    if (counter < 1) {
+                        lineChart.render(data, {theme: 'light', tooltip: true, labelSeriesWithMarker: (counter % 2 === 0)}, [{},{timeShift: '-1m', variableAlias: 'd'}, {startAt: from.toISOString(), variableAlias: 'this is a prettttty long variable alias', searchSpan: {from: from.valueOf(), to: to.valueOf()}}]);
                     }
                     counter++;
                 }, 2000);

--- a/pages/examples/testcases/startat.html
+++ b/pages/examples/testcases/startat.html
@@ -1,0 +1,69 @@
+
+<!DOCTYPE html> 
+<html>
+    <head>
+        <title>Basic Charts</title>
+
+        <!-- boilerplate headers are injected with head.js, grab them from the live example header, or include a link to head.js -->
+        <script src="../boilerplate/head.js"></script>
+            <!-- boilerplate auth code is injected with auth.js, check it out for auth setup -->
+    <script src="../boilerplate/auth.js"></script>
+    <link rel="stylesheet" type="text/css" href="../styles.css" />
+
+    </head>
+    <body style="font-family: 'Segoe UI', sans-serif;">
+        <div style='margin-top:40px'>
+            <div id='series0StartAt' style='width: 100%; height: 60px; position: relative;'></div>
+        </div>
+        <div style="display:flex;">
+            <div id="chart1" style="width: 50%; height: 500px; margin-top: 40px;"></div>
+            <div id="chart2" style="width: 50%; height: 500px; margin-top: 40px;"></div>    
+        </div>
+        <script>
+            var aggregateExpressions = [];
+
+            window.onload = function() {
+                var tsiClient = new TsiClient();
+                initAuth('Start at');  // initiate auth objects, header, and login modal
+                            
+                // create aggregate expressions, they are S1/S2 SKU query objects
+                var startDate = new Date('2017-04-14T13:00:00Z');
+                var endDate = new Date(startDate.valueOf() + 1000*60*60*1);
+                var searchSpan = {
+                    from: startDate,
+                    to: endDate,
+                    bucketSize:'1m'
+                }
+                aggregateExpressions.push(new tsiClient.ux.AggregateExpression({predicateString: "Factory = 'Factory1'"}, {property: 'Pressure', type: "Double"}, ['avg', 'min', 'max'],
+                    searchSpan, {property: 'Station', type: 'String'}, {alias: 'Shifted time'}));
+                aggregateExpressions.push(new tsiClient.ux.AggregateExpression({predicateString: "Factory = 'Factory1'"}, {property: 'Pressure', type: "Double"}, ['avg', 'min', 'max'],
+                    searchSpan, {property: 'Station', type: 'String'}, 'orange', 'Normal time'));
+                
+                    var lineChart = new tsiClient.ux.LineChart(document.getElementById('chart1'));
+                    var heatmap = new tsiClient.ux.Heatmap(document.getElementById('chart2'));
+
+                    function renderLinechart () {
+                    authContext.getTsiToken().then(function(token){
+                        tsiClient.server.getAggregates(token, '10000000-0000-0000-0000-100000000108.env.timeseries.azure.com', aggregateExpressions.map(function(ae){return ae.toTsx()})).then(function(result){
+                            var transformedResult = tsiClient.ux.transformAggregatesForVisualization(result, aggregateExpressions);
+                            lineChart.render(transformedResult, {theme: 'light', grid: true, tooltip: true}, aggregateExpressions);
+                            heatmap.render(transformedResult, {theme: 'light'}, aggregateExpressions);
+                        });
+                    });
+                }
+                renderLinechart();
+
+                applyShift = function (startAt, i) {
+                    aggregateExpressions[i].startAt = startAt;
+                    renderLinechart();
+                }
+            
+                var dtpSeries0 = new tsiClient.ux.DateTimeButtonSingle(document.getElementById('series0StartAt'));
+                dtpSeries0.render({}, 0, Infinity, startDate, (t) => {
+                    let dateString = (new Date(t)).toISOString();
+                    applyShift(dateString, 0);
+                });
+            };
+        </script>
+    </body>
+</html>

--- a/src/UXClient/Components/DateTimeButtonSingle/DateTimeButtonSingle.ts
+++ b/src/UXClient/Components/DateTimeButtonSingle/DateTimeButtonSingle.ts
@@ -17,6 +17,7 @@ class DateTimeButtonSingle extends DateTimeButton {
         if (millis !== null) {
             this.dateTimeButton.text(this.buttonDateTimeFormat(millis));
             this.selectedMillis = millis;
+            this.onSet(millis);
         }
         this.dateTimePickerContainer.style("display", "none");
         this.dateTimeButton.node().focus();

--- a/src/UXClient/Components/Marker/Marker.ts
+++ b/src/UXClient/Components/Marker/Marker.ts
@@ -6,7 +6,7 @@ import { ChartOptions } from '../../Models/ChartOptions';
 import { LineChartData } from '../../Models/LineChartData';
 import { Tooltip } from '../Tooltip/Tooltip';
 import { ChartComponentData } from '../../Models/ChartComponentData';
-import { KeyCodes } from '../../Constants/Enums';
+import { KeyCodes, ShiftTypes } from '../../Constants/Enums';
 
 const MARKERSTRINGMAXLENGTH = 250;
 const MARKERVALUEMAXWIDTH = 80;
@@ -76,7 +76,7 @@ class Marker extends Component {
         let shiftTuple = this.chartComponentData.getTemporalShiftStringTuple(d.aggregateKey);
         let shiftString = '';
         if (shiftTuple !== null) {
-            shiftString = shiftTuple[0] === 'Start at' ? this.timeFormat(new Date(shiftTuple[1])) : shiftTuple[1]; 
+            shiftString = shiftTuple[0] === ShiftTypes.startAt ? this.timeFormat(new Date(shiftTuple[1])) : shiftTuple[1]; 
         }
 
         let labelDatum = {

--- a/src/UXClient/Components/Marker/Marker.ts
+++ b/src/UXClient/Components/Marker/Marker.ts
@@ -72,11 +72,17 @@ class Marker extends Component {
         text.append('h4')
             .attr('class', 'tsi-seriesLabelGroupName tsi-tooltipTitle')
             .text(d.aggregateName);
+        
+        let shiftTuple = this.chartComponentData.getTemporalShiftStringTuple(d.aggregateKey);
+        let shiftString = '';
+        if (shiftTuple !== null) {
+            shiftString = shiftTuple[0] === 'Start at' ? this.timeFormat(new Date(shiftTuple[1])) : shiftTuple[1]; 
+        }
 
         let labelDatum = {
             splitBy: d.splitBy,
             variableAlias: this.chartComponentData.displayState[d.aggregateKey].aggregateExpression.variableAlias,
-            timeShift: this.chartComponentData.getTemporalShiftString(d.aggregateKey),
+            timeShift: shiftString,
         }
 
         let subtitle = text.selectAll('.tsi-seriesLabelSeriesName').data([labelDatum]);

--- a/src/UXClient/Constants/Enums.ts
+++ b/src/UXClient/Constants/Enums.ts
@@ -11,3 +11,4 @@ export enum InstancesSort {DisplayName = "DisplayName", Rank = "Rank"};
 export enum HierarchiesExpand {UntilChildren = "UntilChildren", OneLevel = "OneLevel"};
 export enum HierarchiesSort {Name = "Name", CumulativeInstanceCount = "CumulativeInstanceCount"};
 export enum MetadataPropertyTypes {Double = "Double", String = "String", DateTime = "DateTime", Long = "Long"}
+export enum ShiftTypes {startAt = "Start at", shifted = "shifted"}

--- a/src/UXClient/Interfaces/ChartComponent.ts
+++ b/src/UXClient/Interfaces/ChartComponent.ts
@@ -6,6 +6,7 @@ import { EllipsisMenu } from "../Components/EllipsisMenu/EllipsisMenu";
 import * as d3 from 'd3';
 import Split from 'split.js';
 import { Legend } from "../Components/Legend/Legend";
+import { ShiftTypes } from "../Constants/Enums";
 
 
 class ChartComponent extends Component {
@@ -194,7 +195,7 @@ class ChartComponent extends Component {
 			let shiftTuple = this.chartComponentData.getTemporalShiftStringTuple(d.aggregateKey);
 			if (shiftTuple !== null) {
 				let keyString = this.getString(shiftTuple[0]);
-				let valueString = (keyString === 'Start at') ? this.formatDate(new Date(shiftTuple[1]), 0) : shiftTuple[1]; 
+				let valueString = (keyString === ShiftTypes.startAt) ? this.formatDate(new Date(shiftTuple[1]), 0) : shiftTuple[1]; 
 				tooltipAttrs = [...tooltipAttrs, [keyString, valueString]];
 			}
         }

--- a/src/UXClient/Interfaces/ChartComponent.ts
+++ b/src/UXClient/Interfaces/ChartComponent.ts
@@ -192,9 +192,11 @@ class ChartComponent extends Component {
         let tooltipAttrs = cDO.tooltipAttributes;
         if (shiftMillis !== 0 && tooltipAttrs) {
 			let shiftTuple = this.chartComponentData.getTemporalShiftStringTuple(d.aggregateKey);
-			let keyString = this.getString(shiftTuple[0]);
-			let valueString = (keyString === 'Start at') ? this.formatDate(new Date(shiftTuple[1]), 0) : shiftTuple[1]; 
-            tooltipAttrs = [...tooltipAttrs, [keyString, valueString]];
+			if (shiftTuple !== null) {
+				let keyString = this.getString(shiftTuple[0]);
+				let valueString = (keyString === 'Start at') ? this.formatDate(new Date(shiftTuple[1]), 0) : shiftTuple[1]; 
+				tooltipAttrs = [...tooltipAttrs, [keyString, valueString]];
+			}
         }
 
         if (tooltipAttrs && tooltipAttrs.length > 0) {

--- a/src/UXClient/Interfaces/ChartComponent.ts
+++ b/src/UXClient/Interfaces/ChartComponent.ts
@@ -205,7 +205,10 @@ class ChartComponent extends Component {
 
         let tooltipAttrs = cDO.tooltipAttributes;
         if (shiftMillis !== 0 && tooltipAttrs) {
-            tooltipAttrs = [...tooltipAttrs, [this.getString("shifted"), this.chartComponentData.getTemporalShiftString(d.aggregateKey)]];
+			let shiftTuple = this.chartComponentData.getTemporalShiftStringTuple(d.aggregateKey);
+			let keyString = this.getString(shiftTuple[0]);
+			let valueString = (keyString === 'Start at') ? this.formatDate(new Date(shiftTuple[1]), 0) : shiftTuple[1]; 
+            tooltipAttrs = [...tooltipAttrs, [keyString, valueString]];
         }
 
         if (tooltipAttrs && tooltipAttrs.length > 0) {

--- a/src/UXClient/Models/AggregateExpression.ts
+++ b/src/UXClient/Models/AggregateExpression.ts
@@ -19,7 +19,7 @@ class AggregateExpression extends ChartDataOptions {
     
     public toTsx(roundFromTo: boolean = false){
         var tsx = {};
-        let shiftMillis = Utils.parseShift(this.timeShift);
+        let shiftMillis = Utils.parseShift(this.timeShift, this.startAt, this.searchSpan);
         let fromMillis = this.searchSpan.from.valueOf() + shiftMillis;
         let toMillis = this.searchSpan.to.valueOf() + shiftMillis;
         let bucketSizeInMillis = Utils.parseTimeInput(this.searchSpan.bucketSize);

--- a/src/UXClient/Models/ChartComponentData.ts
+++ b/src/UXClient/Models/ChartComponentData.ts
@@ -1,5 +1,6 @@
 import {Utils, DataTypes, valueTypes} from "./../Utils";
 import { ChartDataOptions } from "./ChartDataOptions";
+import { ShiftTypes } from "../Constants/Enums";
 
 class ChartComponentData {
     public data: any = {};
@@ -258,10 +259,10 @@ class ChartComponentData {
         let ae = this.displayState[aggKey].aggregateExpression;
         if (ae) {
             if (Utils.isStartAt(ae.startAt, ae.searchSpan)) {
-                return ['Start at', ae.startAt];
+                return [ShiftTypes.startAt, ae.startAt];
             }
             if (ae.timeShift) {
-                return ['shifted', ae.timeShift];
+                return [ShiftTypes.shifted, ae.timeShift];
             }    
         }
         return null;

--- a/src/UXClient/Models/ChartComponentData.ts
+++ b/src/UXClient/Models/ChartComponentData.ts
@@ -264,13 +264,12 @@ class ChartComponentData {
                 return ['shifted', ae.timeShift];
             }    
         }
-        return '';
+        return null;
     } 
 
     public getTemporalShiftMillis (aggKey) {
         let ae = this.displayState[aggKey].aggregateExpression;
         if (ae) {
-            console.log(ae.startAt);
             return Utils.parseShift(ae.timeShift, ae.startAt, ae.searchSpan);
         }
         return 0;

--- a/src/UXClient/Models/ChartComponentData.ts
+++ b/src/UXClient/Models/ChartComponentData.ts
@@ -167,10 +167,12 @@ class ChartComponentData {
             this.visibleTAs[aggKey] = {};
 
             Object.keys(data[i][aggName]).forEach((splitBy: string, splitByI: number) => {
-                this.timeArrays[aggKey][splitBy] = 
-                    this.convertAggregateToArray(data[i][aggName][splitBy], aggKey, aggName, splitBy, 
+                let shiftValue = Utils.parseShift(aggregateExpressionOptions[i].timeShift, 
+                    aggregateExpressionOptions[i].startAt, 
+                    aggregateExpressionOptions[i].searchSpan);
+                this.timeArrays[aggKey][splitBy] = this.convertAggregateToArray(data[i][aggName][splitBy], aggKey, aggName, splitBy, 
                                                  newDisplayState[aggKey].from, newDisplayState[aggKey].to, 
-                                                 newDisplayState[aggKey].bucketSize, aggregateExpressionOptions[i].timeShift);  
+                                                 newDisplayState[aggKey].bucketSize, shiftValue);  
                 if (newDisplayState[aggKey].dataType === DataTypes.Categorical && aggregateExpressionOptions[i].rollupCategoricalValues){
                     this.timeArrays[aggKey][splitBy] = Utils.rollUpContiguous(this.timeArrays[aggKey][splitBy]);
                 }             
@@ -252,17 +254,25 @@ class ChartComponentData {
         return Object.keys(measureTypes);
     }
 
-    public getTemporalShiftString (aggKey) {
-        if (this.displayState[aggKey].aggregateExpression && this.displayState[aggKey].aggregateExpression.timeShift) {
-            return this.displayState[aggKey].aggregateExpression.timeShift;
+    public getTemporalShiftStringTuple (aggKey) {
+        let ae = this.displayState[aggKey].aggregateExpression;
+        if (ae) {
+            if (Utils.isStartAt(ae.startAt, ae.searchSpan)) {
+                return ['Start at', ae.startAt];
+            }
+            if (ae.timeShift) {
+                return ['shifted', ae.timeShift];
+            }    
         }
         return '';
     } 
 
     public getTemporalShiftMillis (aggKey) {
-        if (this.displayState[aggKey].aggregateExpression && this.displayState[aggKey].aggregateExpression.timeShift) {
-            return Utils.parseShift(this.displayState[aggKey].aggregateExpression.timeShift);
-        } 
+        let ae = this.displayState[aggKey].aggregateExpression;
+        if (ae) {
+            console.log(ae.startAt);
+            return Utils.parseShift(ae.timeShift, ae.startAt, ae.searchSpan);
+        }
         return 0;
     }
 
@@ -356,11 +366,10 @@ class ChartComponentData {
     //aggregates object => array of objects containing timestamp and values. Pad with 
     public convertAggregateToArray (agg: any, aggKey: string, aggName: string, splitBy: string, 
                                     from: Date = null, to: Date = null, bucketSize: number = null, 
-                                    timeShift: string): Array<any> {
+                                    shiftValue: number): Array<any> {
         
         let aggArray: Array<any> = [];
         let isoStringAgg = {};
-        let shiftValue = Utils.parseShift(timeShift);
         Object.keys(agg).forEach((dateString: string) => {
             let shiftedDate = new Date((new Date(dateString)).valueOf() - shiftValue);
             let jsISOString = shiftedDate.toISOString();

--- a/src/UXClient/Models/ChartDataOptions.ts
+++ b/src/UXClient/Models/ChartDataOptions.ts
@@ -15,6 +15,7 @@ class ChartDataOptions {
     public includeDots: boolean = false;
     public visibilityState: Array<any> = null;
     public timeShift: string;
+    public startAt: string;
     public dataType: string; //numeric, categorical, events?
     public valueMapping: any; //only present for non-numeric
     public height: number; //only present for non-numeric
@@ -56,6 +57,7 @@ class ChartDataOptions {
         this.positionXVariableName = Utils.getValueOrDefault(optionsObject, 'positionXVariableName', null);
         this.positionYVariableName = Utils.getValueOrDefault(optionsObject, 'positionYVariableName', null);
         this.image = Utils.getValueOrDefault(optionsObject, 'image', null);
+        this.startAt = Utils.getValueOrDefault(optionsObject, 'startAt', null);
     }
 }
 export {ChartDataOptions}

--- a/src/UXClient/Models/Strings.ts
+++ b/src/UXClient/Models/Strings.ts
@@ -105,7 +105,8 @@ class Strings {
         "Failed to get instance details": "Failed to get instance details",
         "Add": "Add",
         "Search": "Search",
-        "Marker": "Marker"
+        "Marker": "Marker",
+        "Start at": "Start at"
     };
   
     private stringValues: any = {};

--- a/src/UXClient/Models/TsqExpression.ts
+++ b/src/UXClient/Models/TsqExpression.ts
@@ -35,7 +35,7 @@ class TsqExpression extends ChartDataOptions {
 
     public toTsq(roundFromTo: boolean = false, getEvents: boolean = false){
         var tsq = {};
-        let shiftMillis = Utils.parseShift(this.timeShift);
+        let shiftMillis = Utils.parseShift(this.timeShift, this.startAt, this.searchSpan);
         let fromMillis = this.searchSpan.from.valueOf() + shiftMillis;
         let toMillis = this.searchSpan.to.valueOf() + shiftMillis;
         let bucketSizeInMillis = Utils.parseTimeInput(this.searchSpan.bucketSize);

--- a/src/UXClient/Utils.ts
+++ b/src/UXClient/Utils.ts
@@ -107,16 +107,24 @@ class Utils {
         } 
         return null;
     }
+
+    static isStartAt (startAtString: string = null, searchSpan: any = null) {
+        return (startAtString !== null && searchSpan !== null && searchSpan.from !== null);
+    }
     
-    static parseShift (inputString: string) {
-        if (inputString === undefined || inputString === null || inputString.length === 0) {
+    static parseShift (shiftString: string, startAtString: any = null, searchSpan: any = null) {
+        if (this.isStartAt(startAtString, searchSpan)) {
+            return (new Date(startAtString)).valueOf() - (new Date(searchSpan.from)).valueOf();
+        }
+        
+        if (shiftString === undefined || shiftString === null || shiftString.length === 0) {
             return 0;
         }
         let millis: number;
-        if (inputString[0] === '-' || inputString[0] === '+') {
-            millis = (inputString[0] === '-' ? -1 : 1) * this.parseTimeInput(inputString.slice(1,inputString.length));
+        if (shiftString[0] === '-' || shiftString[0] === '+') {
+            millis = (shiftString[0] === '-' ? -1 : 1) * this.parseTimeInput(shiftString.slice(1,shiftString.length));
         } else {
-            millis = this.parseTimeInput(inputString);
+            millis = this.parseTimeInput(shiftString);
         }
         return millis;
     }
@@ -755,7 +763,7 @@ class Utils {
             let newTS = {}
             Object.keys(query.data[query.alias][""]).forEach((key) => {
                 let oldTime = new Date(key).valueOf();
-                let timeShift = query.timeShift != "" ? this.parseShift(query.timeShift): 0;
+                let timeShift = query.timeShift != "" ? this.parseShift(query.timeShift, query.startAt, query.searchSpan): 0;
                 // Calculate real timeshift based on bucket snapping
                 let bucketShiftInMillis =  this.adjustStartMillisToAbsoluteZero(timeShift, this.parseShift(query.searchSpan.bucketSize));
                 let normalizedTime = oldTime - bucketShiftInMillis;


### PR DESCRIPTION
Introduces the ChartDataOption of **startAt**, an alternative to timeShift to create a disconnect between the global searchSpan, and that dataGroup's searchSpan. A startAt is passed in as in ISOString. 

Changes to code/behavior:
- timeShift, as it is internally stored in an AggregateExpression or a TSQExpression, is now either coming directly from the ChartDataOption timeShift, OR is derived from the difference between startAt and searchSpan.from
- the tooltip has been updated to either display "Shifted" or "Start at" to reflect where the timeShift is coming from
- fix to SingleDateTimePickerButton to actually call onSet
- small change to series label code to ensure that labels display start at in the label
- Test case of startat.html added