### PR TITLE
Swimlane labels

### DIFF
--- a/pages/examples/testcases/swimLanes/swimLaneLabels.html
+++ b/pages/examples/testcases/swimLanes/swimLaneLabels.html
@@ -20,7 +20,7 @@
                 <option>5</option>
             </select>
             <input id="group0Label" value="lane 1"></input>
-            <label>Group 0 label</label>
+            <label>Lane 1 label</label>
             <br/>
             <span>group 1: </span>
             <select id='group1Select'>
@@ -31,7 +31,7 @@
                 <option>5</option>
             </select>
             <input id="group1Label" value="lane 2"></input>
-            <label>Group 1 label</label>
+            <label>Lane 2 label</label>
             <br/>
             <span>group 2: </span>
             <select id='group2Select'>
@@ -42,7 +42,7 @@
                 <option>5</option>
             </select>
             <input id="group2Label" value="lane 3"></input>
-            <label>Group 2 label</label>
+            <label>Lane 3 label</label>
             <br/>
             <span>group 3: </span>
             <select id='group3Select'>
@@ -53,7 +53,7 @@
                 <option>5</option>
             </select>
             <input id="group3Label" value="lane 4"></input>
-            <label>Group 3 label</label>
+            <label>Lane 4 label</label>
             <br/>
             <span>group 4: </span>
             <select id='group4Select'>
@@ -64,7 +64,7 @@
                 <option selected>5</option>
             </select>
             <input id="group4Label" value="lane 5"></input>
-            <label>Group 4 label</label>
+            <label>Lane 5 label</label>
         </div>
         <script>
             window.onload = function() {

--- a/pages/examples/testcases/swimLanes/swimLaneLabels.html
+++ b/pages/examples/testcases/swimLanes/swimLaneLabels.html
@@ -193,11 +193,11 @@
                             {dataType: 'numeric', searchSpan: searchSpan, onElementClick: onElementClick, swimLane: 5}]; 
 
                 var swimLaneOptions = {
-                    1: {yAxisType: 'overlap', label: 'lane 1'},
-                    2: {yAxisType: 'shared', label: 'lane 2'},
-                    3: {yAxisType: 'overlap', label: 'lane 3'},
-                    4: {yAxisType: 'stacked', label: 'lane 4'},
-                    5: {yAxisType: 'stacked', label: 'lane 5'}
+                    1: {yAxisType: 'shared'},
+                    2: {yAxisType: 'overlap'},
+                    3: {yAxisType: 'shared'},
+                    4: {yAxisType: 'overlap'},
+                    5: {yAxisType: 'shared'}
                 }
 
                 var renderLinechart = function () {
@@ -216,6 +216,8 @@
                     swimLaneOptions[swimLane].onClick = (lane) => console.log(`${lane} clicked`);
                     renderLinechart();
                 }
+
+                Object.keys(swimLaneOptions).forEach((key) => changeLabelAndRender(key, `lane ${key}`))
 
                 // Swimlane change listeners
                 document.getElementById(`group0Select`).onchange = function(evt) { changeSwimLaneAndRender(0, Number(evt.target.value))};

--- a/pages/examples/testcases/swimLanes/swimLaneLabels.html
+++ b/pages/examples/testcases/swimLanes/swimLaneLabels.html
@@ -1,0 +1,236 @@
+
+<!DOCTYPE html> 
+<html>
+    <head>
+        <title>Swimlane Labels</title>
+
+        <!-- boilerplate headers are injected with head.js, grab them from the live example header, or include a link to head.js -->
+        <script src="../../boilerplate/head.js"></script>
+    </head>
+    <body style="font-family: 'Segoe UI', sans-serif;">
+        <div id="chart1" style="width: 100%; height: 600px;"></div>
+        <div>
+            <h2>Lane selections:</h2>
+            <span>group 0: </span>
+            <select id='group0Select'>
+                <option selected>1</option>
+                <option>2</option>
+                <option>3</option>
+                <option>4</option>
+                <option>5</option>
+            </select>
+            <input id="group0Label"></input>
+            <label>Group 0 label</label>
+            <br/>
+            <span>group 1: </span>
+            <select id='group1Select'>
+                <option>1</option>
+                <option selected>2</option>
+                <option>3</option>
+                <option>4</option>
+                <option>5</option>
+            </select>
+            <input id="group1Label"></input>
+            <label>Group 1 label</label>
+            <br/>
+            <span>group 2: </span>
+            <select id='group2Select'>
+                <option>1</option>
+                <option>2</option>
+                <option selected>3</option>
+                <option>4</option>
+                <option>5</option>
+            </select>
+            <input id="group2Label"></input>
+            <label>Group 2 label</label>
+            <br/>
+            <span>group 3: </span>
+            <select id='group3Select'>
+                <option>1</option>
+                <option>2</option>
+                <option>3</option>
+                <option selected>4</option>
+                <option>5</option>
+            </select>
+            <input id="group3Label"></input>
+            <label>Group 3 label</label>
+            <br/>
+            <span>group 4: </span>
+            <select id='group4Select'>
+                <option>1</option>
+                <option>2</option>
+                <option>3</option>
+                <option>4</option>
+                <option selected>5</option>
+            </select>
+            <input id="group4Label"></input>
+            <label>Group 4 label</label>
+        </div>
+        <script>
+            window.onload = function() {
+                // create fake data in the shape our charts expect
+                let numberOfBuckets = 120;
+                var data = [];
+                var from = new Date(Math.floor((new Date()).valueOf() / (1000*60 * 60)) * (1000*60 * 60));
+                var to;
+                for(var i = 0; i < 3; i++){
+                    var lines = {};
+                    data.push({[`Factory${i}`]: lines});
+                    var values = {};
+                    lines[``] = values;
+                    for(var k = 0; k < numberOfBuckets; k++){
+                        if (i % 2 === 0) {
+                            // if(!(k%2 && k%3)){  // if check is to create some sparseness in the data
+                                var to = new Date(from.valueOf() + 1000*60*k);
+                                var val = Math.random() + (j !== 4 ? 2 : 0);
+                                var val2 = Math.random();
+                                var val3 = Math.random();
+                                var val4 = Math.random();
+                                values[to.toISOString()] = {avg: val, x: val2, y: val3, r: val4};
+                            // }
+                        } else {
+                            var val1 = Math.random();
+                            if (val1 < .5) {
+                                val1 = 1;
+                            }
+                            var val2 = (1 - val1) / 2;
+                            var val3 = (1 - val1) / 2;
+                            var to = new Date(from.valueOf() + 1000*60*k);
+                            if(Math.random() < .2)
+                                values[to.toISOString()] = {state1: val1, state2: val2, state3: val3};
+                            else
+                                values[to.toISOString()] = null;
+                        }
+                    } 
+                }
+                var random1Through10 = function () {
+                    return Math.ceil(Math.random() * 10);
+                }
+
+                var lines = {};
+                var events = {};
+                data.push({[`Factory3`]: events});
+                data.push({[`Factory 4`]: lines})
+                for(var j = 0; j < 1; j++){
+                        var values = {};
+                        lines[`Station${j}`] = values;
+                        events[`Station${j}`] = {};
+                        for(var k = 0; k < numberOfBuckets; k++){
+                            var val1 = Math.random(); 
+                            var val2 = 1- val1;
+                            var val3 = 0;
+                            if (j === 1) {
+                                val1 = 0;
+                                val2 = 1;
+                                val3 = 0;
+                            } 
+                            if (j === 2) {
+                                val1 = 0;
+                                val2 = 0;
+                                val3 = 1;
+                            }
+                            let previousTo = to;
+                            var toLocal = new Date(from.valueOf() + 1000*60*k);
+                            values[toLocal.toISOString()] = {state1: val1, state2: val2, state3: val3};
+
+                            if (Math.random() > .8) {
+                                let goodOrBad = Math.random() > .5;
+                                let goodAndBad = Math.random() > .8;
+                                let localEvent = {};
+                                events[`Station${j}`][toLocal.toISOString()] = localEvent;
+                                localEvent[goodOrBad ? 'goodEvent' : 'badEvent'] = (goodOrBad ? random1Through10() : random1Through10());
+                                if (goodAndBad) {
+                                    localEvent[goodOrBad ? 'badEvent' : 'goodEvent'] = (!goodOrBad ? random1Through10() : random1Through10());                                    
+                                }
+                                if (Math.random() > .7) {
+                                    localEvent['neutral Event'] = 'neutral message';                                    
+                                }
+                                
+                            }
+                            to = toLocal;
+                    }
+                }
+
+                let searchSpan = {
+                    from: from.toISOString(),
+                    to: new Date(to.valueOf() + 45 * 1000).toISOString(),
+                    bucketSize: '1m'
+                }
+
+
+                // render the data in a chart
+                var tsiClient = new TsiClient();
+                var lineChart = new tsiClient.ux.LineChart(document.getElementById('chart1'));
+                let valueMapping = {
+                    state1: {
+                        color: '#F2C80F'
+                    }, 
+                    state2: {
+                        color: '#FD625E'
+                    },
+                    state3: {
+                        color:'#3599B8'
+                    }
+                }
+                let eventValueMapping = {
+                    badEvent: {
+                        color: 'red'
+                    },
+                    goodEvent: {
+                        color: 'blue'
+                    }
+                }
+                eventValueMapping['neutral Event'] =  { color: 'purple' };
+
+                var onElementClick = function (aggKey, splitBy, ts, measures) {
+                    console.log(aggKey, splitBy, ts, measures);
+                }
+
+                var chartDataOptions = [{dataType: 'numeric', searchSpan: searchSpan, swimLane: 1}, 
+                            {dataType: 'numeric', searchSpan: searchSpan, swimLane: 2}, 
+                            {dataType: 'categorical', valueMapping: valueMapping, height: 50, searchSpan: searchSpan, onElementClick: onElementClick, swimLane: 3},
+                            {dataType: 'events', valueMapping: eventValueMapping, height: 30, eventElementType: 'teardrop', onElementClick: onElementClick, swimLane: 4},
+                            {dataType: 'numeric', searchSpan: searchSpan, onElementClick: onElementClick, swimLane: 5}]; 
+
+                var swimLaneOptions = {
+                    0: {yAxisType: 'overlap'},
+                    1: {yAxisType: 'shared'},
+                    2: {yAxisType: 'overlap'},
+                    3: {yAxisType: 'stacked'},
+                    4: {yAxisType: 'stacked'}
+                }
+
+                var renderLinechart = function () {
+                    lineChart.render(data, {theme: 'light', tooltip: 'true', swimLaneOptions: swimLaneOptions}, chartDataOptions);
+                }
+
+                renderLinechart();
+
+                function changeSwimLaneAndRender (aggGroup, newSwimLane) {
+                    chartDataOptions[aggGroup].swimLane = newSwimLane;
+                    renderLinechart();
+                }
+
+                function changeLabelAndRender(aggGroup, newLabel){
+                    console.log(`Changing group ${aggGroup} to: ${newLabel}`)
+                    swimLaneOptions[aggGroup].label = newLabel;
+                    renderLinechart();
+                }
+
+                // Swimlane change listeners
+                document.getElementById(`group0Select`).onchange = function(evt) { changeSwimLaneAndRender(0, Number(evt.target.value))};
+                document.getElementById(`group1Select`).onchange = function(evt) { changeSwimLaneAndRender(1, Number(evt.target.value))};
+                document.getElementById(`group2Select`).onchange = function(evt) { changeSwimLaneAndRender(2, Number(evt.target.value))};
+                document.getElementById(`group3Select`).onchange = function(evt) { changeSwimLaneAndRender(3, Number(evt.target.value))};
+                document.getElementById(`group4Select`).onchange = function(evt) { changeSwimLaneAndRender(4, Number(evt.target.value))};
+                
+                // Label change listeners
+                document.getElementById(`group0Label`).onchange = function(evt) { changeLabelAndRender(0,evt.target.value)};
+                document.getElementById(`group1Label`).onchange = function(evt) { changeLabelAndRender(1,evt.target.value)};
+                document.getElementById(`group2Label`).onchange = function(evt) { changeLabelAndRender(2,evt.target.value)};
+                document.getElementById(`group3Label`).onchange = function(evt) { changeLabelAndRender(3,evt.target.value)};
+                document.getElementById(`group4Label`).onchange = function(evt) { changeLabelAndRender(4,evt.target.value)};
+            };
+        </script>
+    </body>
+</html>

--- a/pages/examples/testcases/swimLanes/swimLaneLabels.html
+++ b/pages/examples/testcases/swimLanes/swimLaneLabels.html
@@ -193,11 +193,11 @@
                             {dataType: 'numeric', searchSpan: searchSpan, onElementClick: onElementClick, swimLane: 5}]; 
 
                 var swimLaneOptions = {
-                    0: {yAxisType: 'overlap', label: 'lane 1'},
-                    1: {yAxisType: 'shared', label: 'lane 2'},
-                    2: {yAxisType: 'overlap', label: 'lane 3'},
-                    3: {yAxisType: 'stacked', label: 'lane 4'},
-                    4: {yAxisType: 'stacked', label: 'lane 5'}
+                    1: {yAxisType: 'overlap', label: 'lane 1'},
+                    2: {yAxisType: 'shared', label: 'lane 2'},
+                    3: {yAxisType: 'overlap', label: 'lane 3'},
+                    4: {yAxisType: 'stacked', label: 'lane 4'},
+                    5: {yAxisType: 'stacked', label: 'lane 5'}
                 }
 
                 var renderLinechart = function () {
@@ -211,9 +211,9 @@
                     renderLinechart();
                 }
 
-                function changeLabelAndRender(aggGroup, newLabel){
-                    swimLaneOptions[aggGroup].label = newLabel;
-                    swimLaneOptions[aggGroup].onClick = () => console.log(`${newLabel} clicked`);
+                function changeLabelAndRender(swimLane, newLabel){
+                    swimLaneOptions[swimLane].label = newLabel;
+                    swimLaneOptions[swimLane].onClick = () => console.log(`${newLabel} clicked`);
                     renderLinechart();
                 }
 
@@ -225,11 +225,11 @@
                 document.getElementById(`group4Select`).onchange = function(evt) { changeSwimLaneAndRender(4, Number(evt.target.value))};
                 
                 // Label change listeners
-                document.getElementById(`group0Label`).onchange = function(evt) { changeLabelAndRender(0,evt.target.value)};
-                document.getElementById(`group1Label`).onchange = function(evt) { changeLabelAndRender(1,evt.target.value)};
-                document.getElementById(`group2Label`).onchange = function(evt) { changeLabelAndRender(2,evt.target.value)};
-                document.getElementById(`group3Label`).onchange = function(evt) { changeLabelAndRender(3,evt.target.value)};
-                document.getElementById(`group4Label`).onchange = function(evt) { changeLabelAndRender(4,evt.target.value)};
+                document.getElementById(`group0Label`).onchange = function(evt) { changeLabelAndRender(1,evt.target.value)};
+                document.getElementById(`group1Label`).onchange = function(evt) { changeLabelAndRender(2,evt.target.value)};
+                document.getElementById(`group2Label`).onchange = function(evt) { changeLabelAndRender(3,evt.target.value)};
+                document.getElementById(`group3Label`).onchange = function(evt) { changeLabelAndRender(4,evt.target.value)};
+                document.getElementById(`group4Label`).onchange = function(evt) { changeLabelAndRender(5,evt.target.value)};
             };
         </script>
     </body>

--- a/pages/examples/testcases/swimLanes/swimLaneLabels.html
+++ b/pages/examples/testcases/swimLanes/swimLaneLabels.html
@@ -19,7 +19,7 @@
                 <option>4</option>
                 <option>5</option>
             </select>
-            <input id="group0Label"></input>
+            <input id="group0Label" value="lane 1"></input>
             <label>Group 0 label</label>
             <br/>
             <span>group 1: </span>
@@ -30,7 +30,7 @@
                 <option>4</option>
                 <option>5</option>
             </select>
-            <input id="group1Label"></input>
+            <input id="group1Label" value="lane 2"></input>
             <label>Group 1 label</label>
             <br/>
             <span>group 2: </span>
@@ -41,7 +41,7 @@
                 <option>4</option>
                 <option>5</option>
             </select>
-            <input id="group2Label"></input>
+            <input id="group2Label" value="lane 3"></input>
             <label>Group 2 label</label>
             <br/>
             <span>group 3: </span>
@@ -52,7 +52,7 @@
                 <option selected>4</option>
                 <option>5</option>
             </select>
-            <input id="group3Label"></input>
+            <input id="group3Label" value="lane 4"></input>
             <label>Group 3 label</label>
             <br/>
             <span>group 4: </span>
@@ -63,7 +63,7 @@
                 <option>4</option>
                 <option selected>5</option>
             </select>
-            <input id="group4Label"></input>
+            <input id="group4Label" value="lane 5"></input>
             <label>Group 4 label</label>
         </div>
         <script>
@@ -193,11 +193,11 @@
                             {dataType: 'numeric', searchSpan: searchSpan, onElementClick: onElementClick, swimLane: 5}]; 
 
                 var swimLaneOptions = {
-                    0: {yAxisType: 'overlap'},
-                    1: {yAxisType: 'shared'},
-                    2: {yAxisType: 'overlap'},
-                    3: {yAxisType: 'stacked'},
-                    4: {yAxisType: 'stacked'}
+                    0: {yAxisType: 'overlap', label: 'lane 1'},
+                    1: {yAxisType: 'shared', label: 'lane 2'},
+                    2: {yAxisType: 'overlap', label: 'lane 3'},
+                    3: {yAxisType: 'stacked', label: 'lane 4'},
+                    4: {yAxisType: 'stacked', label: 'lane 5'}
                 }
 
                 var renderLinechart = function () {

--- a/pages/examples/testcases/swimLanes/swimLaneLabels.html
+++ b/pages/examples/testcases/swimLanes/swimLaneLabels.html
@@ -82,10 +82,10 @@
                         if (i % 2 === 0) {
                             // if(!(k%2 && k%3)){  // if check is to create some sparseness in the data
                                 var to = new Date(from.valueOf() + 1000*60*k);
-                                var val = Math.random() + (j !== 4 ? 2 : 0);
-                                var val2 = Math.random();
-                                var val3 = Math.random();
-                                var val4 = Math.random();
+                                var val = Math.random() + (j !== 4 ? 2 : 0) * 100000;
+                                var val2 = Math.random()* 100000;
+                                var val3 = Math.random()* 100000;
+                                var val4 = Math.random()* 100000;
                                 values[to.toISOString()] = {avg: val, x: val2, y: val3, r: val4};
                             // }
                         } else {
@@ -201,7 +201,7 @@
                 }
 
                 var renderLinechart = function () {
-                    lineChart.render(data, {theme: 'light', tooltip: 'true', swimLaneOptions: swimLaneOptions}, chartDataOptions);
+                    lineChart.render(data, {theme: 'light', legend: 'compact', tooltip: 'true', swimLaneOptions: swimLaneOptions}, chartDataOptions);
                 }
 
                 renderLinechart();
@@ -212,8 +212,8 @@
                 }
 
                 function changeLabelAndRender(aggGroup, newLabel){
-                    console.log(`Changing group ${aggGroup} to: ${newLabel}`)
                     swimLaneOptions[aggGroup].label = newLabel;
+                    swimLaneOptions[aggGroup].onClick = () => console.log(`${newLabel} clicked`);
                     renderLinechart();
                 }
 

--- a/pages/examples/testcases/swimLanes/swimLaneLabels.html
+++ b/pages/examples/testcases/swimLanes/swimLaneLabels.html
@@ -54,6 +54,8 @@
             </select>
             <input id="group3Label" value="lane 4"></input>
             <label>Lane 4 label</label>
+            Collapse Events
+            <input type="checkbox" id="group3Collapse" unchecked>
             <br/>
             <span>group 4: </span>
             <select id='group4Select'>
@@ -110,7 +112,7 @@
                 var lines = {};
                 var events = {};
                 data.push({[`Factory3`]: events});
-                data.push({[`Factory 4`]: lines})
+                data.push({[`Factory 4`]: lines});
                 for(var j = 0; j < 1; j++){
                         var values = {};
                         lines[`Station${j}`] = values;
@@ -150,6 +152,7 @@
                             to = toLocal;
                     }
                 }
+                data.push({[`Factory5`]: events});
 
                 let searchSpan = {
                     from: from.toISOString(),
@@ -189,14 +192,15 @@
                 var chartDataOptions = [{dataType: 'numeric', searchSpan: searchSpan, swimLane: 1}, 
                             {dataType: 'numeric', searchSpan: searchSpan, swimLane: 2}, 
                             {dataType: 'categorical', valueMapping: valueMapping, height: 50, searchSpan: searchSpan, onElementClick: onElementClick, swimLane: 3},
-                            {dataType: 'events', valueMapping: eventValueMapping, height: 30, eventElementType: 'teardrop', onElementClick: onElementClick, swimLane: 4},
-                            {dataType: 'numeric', searchSpan: searchSpan, onElementClick: onElementClick, swimLane: 5}]; 
+                            {dataType: 'events', valueMapping: eventValueMapping, height: 20, eventElementType: 'teardrop', onElementClick: onElementClick, swimLane: 4},
+                            {dataType: 'numeric', searchSpan: searchSpan, onElementClick: onElementClick, swimLane: 5},
+                            {dataType: 'events', valueMapping: eventValueMapping, height: 40, eventElementType: 'diamond', onElementClick: onElementClick, swimLane: 4}]
 
                 var swimLaneOptions = {
                     1: {yAxisType: 'shared'},
                     2: {yAxisType: 'overlap'},
                     3: {yAxisType: 'shared'},
-                    4: {yAxisType: 'overlap'},
+                    4: {yAxisType: 'overlap', collapseEvents: false},
                     5: {yAxisType: 'shared'}
                 }
 
@@ -217,6 +221,11 @@
                     renderLinechart();
                 }
 
+                function changeEventsCollapse(swimLane){
+                    swimLaneOptions[swimLane].collapseEvents = !swimLaneOptions[swimLane].collapseEvents;
+                    renderLinechart();
+                }
+
                 Object.keys(swimLaneOptions).forEach((key) => changeLabelAndRender(key, `lane ${key}`))
 
                 // Swimlane change listeners
@@ -232,6 +241,9 @@
                 document.getElementById(`group2Label`).onchange = function(evt) { changeLabelAndRender(3,evt.target.value)};
                 document.getElementById(`group3Label`).onchange = function(evt) { changeLabelAndRender(4,evt.target.value)};
                 document.getElementById(`group4Label`).onchange = function(evt) { changeLabelAndRender(5,evt.target.value)};
+
+                // Collapse listener
+                document.getElementById(`group3Collapse`).onchange = function(evt) { changeEventsCollapse(4)};
             };
         </script>
     </body>

--- a/pages/examples/testcases/swimLanes/swimLaneLabels.html
+++ b/pages/examples/testcases/swimLanes/swimLaneLabels.html
@@ -201,7 +201,7 @@
                 }
 
                 var renderLinechart = function () {
-                    lineChart.render(data, {theme: 'light', legend: 'compact', tooltip: 'true', swimLaneOptions: swimLaneOptions}, chartDataOptions);
+                    lineChart.render(data, {theme: 'light', legend: 'compact', tooltip: 'true', swimLaneOptions }, chartDataOptions);
                 }
 
                 renderLinechart();
@@ -213,7 +213,7 @@
 
                 function changeLabelAndRender(swimLane, newLabel){
                     swimLaneOptions[swimLane].label = newLabel;
-                    swimLaneOptions[swimLane].onClick = () => console.log(`${newLabel} clicked`);
+                    swimLaneOptions[swimLane].onClick = (lane) => console.log(`${lane} clicked`);
                     renderLinechart();
                 }
 

--- a/src/UXClient/Components/LineChart/LineChart.scss
+++ b/src/UXClient/Components/LineChart/LineChart.scss
@@ -58,7 +58,13 @@
         .tsi-swimLaneLabel{
             font-weight: 600;
             font-size:13px;
+            opacity: .9;
             cursor: pointer;
+            &:hover, &.axisHover{
+                transition: all .2s ease-in-out;
+                font-size: 15px;
+                opacity: 1;
+            }
         }
     }
 

--- a/src/UXClient/Components/LineChart/LineChart.scss
+++ b/src/UXClient/Components/LineChart/LineChart.scss
@@ -44,7 +44,7 @@
             fill: $gray1 !important;
         }
 
-        .boldYAxisText{
+        .tsi-boldYAxisText{
             font-weight: bolder !important;
         }
 
@@ -62,9 +62,14 @@
         .tsi-swimLaneLabel{
             font-weight: 500;
             font-size:13px;
-            cursor: pointer;
-            &:hover, &.axisHover{
+            &.tsi-axisHover{
                 font-weight: bolder;
+            }
+            &.tsi-boldOnHover{
+                cursor: pointer;
+                &:hover{
+                    font-weight: bolder;
+                }
             }
         }
     }

--- a/src/UXClient/Components/LineChart/LineChart.scss
+++ b/src/UXClient/Components/LineChart/LineChart.scss
@@ -44,6 +44,10 @@
             fill: $gray1 !important;
         }
 
+        .boldYAxisText{
+            font-weight: bolder !important;
+        }
+
         .xAxisBaseline {
             stroke: $gray1 !important;
             pointer-events: none;
@@ -56,14 +60,11 @@
         }
 
         .tsi-swimLaneLabel{
-            font-weight: 600;
+            font-weight: 500;
             font-size:13px;
-            opacity: .9;
             cursor: pointer;
             &:hover, &.axisHover{
-                transition: all .2s ease-in-out;
-                font-size: 15px;
-                opacity: 1;
+                font-weight: bolder;
             }
         }
     }

--- a/src/UXClient/Components/LineChart/LineChart.scss
+++ b/src/UXClient/Components/LineChart/LineChart.scss
@@ -54,6 +54,12 @@
         .tsi-horizontalValueBar {
             stroke: rgba($gray1, .8);
         }
+
+        .tsi-swimLaneLabel{
+            font-weight: 600;
+            font-size:13px;
+            cursor: pointer;
+        }
     }
 
     .tsi-scooterContainer {

--- a/src/UXClient/Components/LineChart/LineChart.ts
+++ b/src/UXClient/Components/LineChart/LineChart.ts
@@ -1367,13 +1367,14 @@ class LineChart extends TemporalXAxisComponent {
                 .style("text-anchor", "middle")
                 .attr("transform", d => `translate(${( -this.horizontalLabelOffset + 28 )},${(d.offset + d.height / 2)}) rotate(-90)`)
                 .text(d => d.label)
-                .attr("title", d => d.label)
                 .each(function(d){truncateLabel(this, d)})
                 .on("click", d => {
                     if(d.onClick && typeof d.onClick === 'function'){
                         d.onClick()
                     }
                 })
+                .append("svg:title")
+                    .text(d => d.label);
 
             label.exit().remove();
         })
@@ -1771,10 +1772,15 @@ class LineChart extends TemporalXAxisComponent {
 
                             let axisState = new AxisState(self.getAggAxisType(agg), yExtent, positionInGroup);
 
+                            let yAxisOnClick = null;
+                            if(typeof self.chartOptions?.swimLaneOptions?.[swimLane]?.onClick === 'function'){
+                                yAxisOnClick = () => self.chartOptions.swimLaneOptions[swimLane].onClick?.(swimLane);
+                            }
+
                             self.plotComponents[aggKey].render(self.chartOptions, visibleNumericI, agg, true, d3.select(this), self.chartComponentData, axisState, 
                                 self.chartHeight, self.visibleAggCount, self.colorMap, self.previousAggregateData, 
                                 self.x, self.areaPath, self.strokeOpacity, self.y, self.yMap, defs, visibleCDOs[i], self.previousIncludeDots, offsetsAndHeights[i], 
-                                g, mouseoverFunction, mouseoutFunction);
+                                g, mouseoverFunction, mouseoutFunction, yAxisOnClick);
                             
                             //increment index of visible numerics if appropriate
                             visibleNumericI += (visibleCDOs[i].dataType === DataTypes.Numeric ? 1 : 0);

--- a/src/UXClient/Components/LineChart/LineChart.ts
+++ b/src/UXClient/Components/LineChart/LineChart.ts
@@ -1299,7 +1299,7 @@ class LineChart extends TemporalXAxisComponent {
                     offset: offsetsAndHeights[i][0],
                     height: offsetsAndHeights[i][1],
                     label: this.chartOptions?.swimLaneOptions?.[swimLane]?.label,
-                    onClick: this.chartOptions?.swimLaneOptions?.[swimLane]?.onClick
+                    onClick: () => this.chartOptions?.swimLaneOptions?.[swimLane]?.onClick?.(swimLane)
                 }
             } else if(aggGroup.dataType !== DataTypes.Numeric){ // if lane contains non-numeric data and is being added to another lane
                 swimLaneLabels[aggGroup.swimLane].height += offsetsAndHeights[i][1]; // add heights (non-numerics don't share Y axis)

--- a/src/UXClient/Components/LineChart/LineChart.ts
+++ b/src/UXClient/Components/LineChart/LineChart.ts
@@ -1293,14 +1293,13 @@ class LineChart extends TemporalXAxisComponent {
 
         // Creates object entry for each swimlane with offset, height, and label
         visibleCDOs.forEach((aggGroup, i) => {
-            console.log(`Index ${i}: `, aggGroup)
-            let swimLaneIdx = aggGroup.swimLane - 1;
+            let swimLane = aggGroup.swimLane;
             if(!(aggGroup.swimLane in swimLaneLabels)){ // Only add swimlanes once to swimLaneLabels map
                 swimLaneLabels[aggGroup.swimLane] = {
                     offset: offsetsAndHeights[i][0],
                     height: offsetsAndHeights[i][1],
-                    label: this.chartOptions?.swimLaneOptions[swimLaneIdx]?.label,
-                    onClick: this.chartOptions?.swimLaneOptions[swimLaneIdx]?.onClick
+                    label: this.chartOptions?.swimLaneOptions?.[swimLane]?.label,
+                    onClick: this.chartOptions?.swimLaneOptions?.[swimLane]?.onClick
                 }
             } else if(aggGroup.dataType !== DataTypes.Numeric){ // if lane contains non-numeric data and is being added to another lane
                 swimLaneLabels[aggGroup.swimLane].height += offsetsAndHeights[i][1]; // add heights (non-numerics don't share Y axis)
@@ -1324,8 +1323,6 @@ class LineChart extends TemporalXAxisComponent {
                 }
             }
         }
-
-        console.log(swimLaneLabels)
 
         // Map over swimLanes and create labels
         Object.keys(swimLaneLabels).forEach(lane => {
@@ -1375,7 +1372,7 @@ class LineChart extends TemporalXAxisComponent {
         }
 
         // Check if any swimlane labels present & modify left margin if so
-        if(Object.keys(this.originalSwimLaneOptions).map(key => this.originalSwimLaneOptions[key]).reduce((acc, curr) => acc  || curr.label ? true: false, false)){
+        if(this.originalSwimLaneOptions && Object.keys(this.originalSwimLaneOptions).map(key => this.originalSwimLaneOptions[key]).reduce((acc, curr) => acc  || curr.label ? true: false, false)){
             this.chartMargins.left = this.horizontalLabelOffset;
         } else{
             this.chartMargins.left = LINECHARTCHARTMARGINS.left;

--- a/src/UXClient/Components/LineChart/LineChart.ts
+++ b/src/UXClient/Components/LineChart/LineChart.ts
@@ -1355,6 +1355,13 @@ class LineChart extends TemporalXAxisComponent {
             }
         }
 
+        const boldYAxisText = (enabled: boolean, lane: string) => {
+            this.svgSelection.select('.svgGroup')
+                .selectAll(`.tsi-swimLaneAxis-${lane}`)
+                .selectAll('text')
+                .classed('boldYAxisText', enabled)
+        }
+
         // Map over swimLanes and create labels
         Object.keys(swimLaneLabels).forEach(lane => {
             let labelData = [swimLaneLabels[lane]];
@@ -1372,6 +1379,12 @@ class LineChart extends TemporalXAxisComponent {
                     if(d.onClick && typeof d.onClick === 'function'){
                         d.onClick()
                     }
+                })
+                .on("mouseover", () => {
+                   boldYAxisText(true, lane);
+                })
+                .on("mouseout", () => {
+                    boldYAxisText(false, lane);
                 })
                 .append("svg:title")
                     .text(d => d.label);

--- a/src/UXClient/Components/LineChart/LineChart.ts
+++ b/src/UXClient/Components/LineChart/LineChart.ts
@@ -1291,27 +1291,19 @@ class LineChart extends TemporalXAxisComponent {
         // Create swimlane label obj
         let swimLaneLabels = {};
 
-        // Function to return swimlane label (if present) otherwise null
-        const getSwimlaneLabel = (swimlaneIdx) => {
-            let swimLaneOptions = this.chartOptions?.swimLaneOptions
-            if(swimLaneOptions && swimlaneIdx in swimLaneOptions){
-                if(swimLaneOptions[swimlaneIdx]?.label){
-                    return swimLaneOptions[swimlaneIdx].label;
-                }
-            }
-            return null;
-        }
-
         // Creates object entry for each swimlane with offset, height, and label
         visibleCDOs.forEach((aggGroup, i) => {
+            console.log(`Index ${i}: `, aggGroup)
             let swimLaneIdx = aggGroup.swimLane - 1;
-            if(!(aggGroup.swimLane in swimLaneLabels)){
+            if(!(aggGroup.swimLane in swimLaneLabels)){ // Only add swimlanes once to swimLaneLabels map
                 swimLaneLabels[aggGroup.swimLane] = {
                     offset: offsetsAndHeights[i][0],
                     height: offsetsAndHeights[i][1],
                     label: this.chartOptions?.swimLaneOptions[swimLaneIdx]?.label,
                     onClick: this.chartOptions?.swimLaneOptions[swimLaneIdx]?.onClick
                 }
+            } else if(aggGroup.dataType !== DataTypes.Numeric){ // if lane contains non-numeric data and is being added to another lane
+                swimLaneLabels[aggGroup.swimLane].height += offsetsAndHeights[i][1]; // add heights (non-numerics don't share Y axis)
             }
         });
 
@@ -1332,6 +1324,8 @@ class LineChart extends TemporalXAxisComponent {
                 }
             }
         }
+
+        console.log(swimLaneLabels)
 
         // Map over swimLanes and create labels
         Object.keys(swimLaneLabels).forEach(lane => {
@@ -1479,7 +1473,7 @@ class LineChart extends TemporalXAxisComponent {
             }
     
             this.focus = g.append("g")
-                .attr("transform", "translate(-100,-100)")
+                .attr("transform", "translate(-200,-100)")
                 .attr("class", "tsi-focus");
             
             this.focus.append("line")

--- a/src/UXClient/Components/LineChart/LineChart.ts
+++ b/src/UXClient/Components/LineChart/LineChart.ts
@@ -1418,7 +1418,7 @@ class LineChart extends TemporalXAxisComponent {
         // Check if any swimlane labels present & modify left margin if so
         if(this.originalSwimLaneOptions && Object.keys(this.originalSwimLaneOptions).map(key => this.originalSwimLaneOptions[key]).reduce((acc, curr) => acc  || curr.label ? true: false, false)){
             this.chartMargins.left = this.horizontalLabelOffset;
-        } else{
+        } else if (this.chartMargins.left === this.horizontalLabelOffset){
             this.chartMargins.left = LINECHARTCHARTMARGINS.left;
         }
 

--- a/src/UXClient/Components/LinePlot/LinePlot.scss
+++ b/src/UXClient/Components/LinePlot/LinePlot.scss
@@ -1,3 +1,3 @@
-.clickableYAxis{
+.tsi-clickableYAxis{
     cursor: pointer;
 }

--- a/src/UXClient/Components/LinePlot/LinePlot.scss
+++ b/src/UXClient/Components/LinePlot/LinePlot.scss
@@ -1,0 +1,3 @@
+.clickableYAxis{
+    cursor: pointer;
+}

--- a/src/UXClient/Components/LinePlot/LinePlot.ts
+++ b/src/UXClient/Components/LinePlot/LinePlot.ts
@@ -48,7 +48,7 @@ class LinePlot extends Plot {
    // returns the next visibleAggI
     public render (chartOptions, visibleAggI, agg, aggVisible: boolean, aggregateGroup, chartComponentData, yAxisState: AxisState,  
         chartHeight, visibleAggCount, colorMap, previousAggregateData, x, areaPath, strokeOpacity, y, yMap, defs, chartDataOptions,
-        previousIncludeDots, yTopAndHeight, svgSelection, categoricalMouseover, categoricalMouseout) {
+        previousIncludeDots, yTopAndHeight, svgSelection, categoricalMouseover, categoricalMouseout, yAxisOnClick) {
         this.previousIncludeDots = previousIncludeDots;
         this.defs = defs;
         this.chartOptions = chartOptions;
@@ -59,6 +59,7 @@ class LinePlot extends Plot {
         this.y = y;
         let aggKey = agg.aggKey;
         this.aggregateGroup = aggregateGroup;
+        const yAxisHasOnClick = yAxisOnClick && typeof yAxisOnClick === "function";
 
         visibleAggI = yAxisState.positionInGroup;
 
@@ -117,9 +118,25 @@ class LinePlot extends Plot {
         
         yAxis = yAxis.enter()
             .append("g")
-            .attr("class", "yAxis")
+            .attr("class", `yAxis ${yAxisHasOnClick ? 'clickableYAxis' : ''}`)
             .merge(yAxis)
             .style("visibility", ((visibleYAxis && !this.chartOptions.yAxisHidden) ? "visible" : "hidden"));
+
+        // If yAxisOnClick present, attach to yAxis
+        if(yAxisHasOnClick){
+            yAxis.on("click", () => {
+                yAxisOnClick();
+            })
+            let label = document.getElementsByClassName(`tsi-swimLaneLabel-${agg.swimLane}`)[0];
+            if(label){
+                yAxis.on("mouseover", () => {
+                    label.classList.add("axisHover");
+                })
+                yAxis.on("mouseout", () => {
+                    label.classList.remove("axisHover");
+                })
+            }
+        }
         if (this.yAxisState.axisType === YAxisStates.Overlap) {
             yAxis.call(d3.axisLeft(aggY).tickFormat(Utils.formatYAxisNumber).tickValues(yExtent))
                 .selectAll("text")

--- a/src/UXClient/Components/LinePlot/LinePlot.ts
+++ b/src/UXClient/Components/LinePlot/LinePlot.ts
@@ -142,12 +142,12 @@ class LinePlot extends Plot {
             let label = document.getElementsByClassName(`tsi-swimLaneLabel-${agg.swimLane}`)[0];
             if(label){
                 yAxis.on("mouseover", () => {
-                    label.classList.add("axisHover");
-                    yAxis.selectAll("text").classed("boldYAxisText", true)
+                    label.classList.add("tsi-axisHover");
+                    yAxis.selectAll("text").classed("tsi-boldYAxisText", true)
                 })
                 yAxis.on("mouseout", () => {
-                    label.classList.remove("axisHover");
-                    yAxis.selectAll("text").classed("boldYAxisText", false)
+                    label.classList.remove("tsi-axisHover");
+                    yAxis.selectAll("text").classed("tsi-boldYAxisText", false)
                 })
             }
         }

--- a/src/UXClient/Components/LinePlot/LinePlot.ts
+++ b/src/UXClient/Components/LinePlot/LinePlot.ts
@@ -118,7 +118,7 @@ class LinePlot extends Plot {
 
         yAxis = yAxis.enter()
             .append("g")
-            .attr("class", `yAxis ${yAxisHasOnClick ? `clickableYAxis tsi-swimLaneAxis-${this.chartComponentData.displayState[aggKey].aggregateExpression.swimLane}` : ''}`)
+            .attr("class", `yAxis ${yAxisHasOnClick ? `tsi-clickableYAxis tsi-swimLaneAxis-${this.chartComponentData.displayState[aggKey].aggregateExpression.swimLane}` : ''}`)
             .merge(yAxis)
             .style("visibility", ((visibleYAxis && !this.chartOptions.yAxisHidden) ? "visible" : "hidden"));
 

--- a/src/UXClient/Components/LinePlot/LinePlot.ts
+++ b/src/UXClient/Components/LinePlot/LinePlot.ts
@@ -115,28 +115,13 @@ class LinePlot extends Plot {
         var yAxis: any = this.aggregateGroup.selectAll(".yAxis")
                         .data([aggKey]);
         var visibleYAxis = (aggVisible && (this.yAxisState.axisType !== YAxisStates.Shared || visibleAggI === 0));
-        
+
         yAxis = yAxis.enter()
             .append("g")
-            .attr("class", `yAxis ${yAxisHasOnClick ? 'clickableYAxis' : ''}`)
+            .attr("class", `yAxis ${yAxisHasOnClick ? `clickableYAxis tsi-swimLaneAxis-${this.chartComponentData.displayState[aggKey].aggregateExpression.swimLane}` : ''}`)
             .merge(yAxis)
             .style("visibility", ((visibleYAxis && !this.chartOptions.yAxisHidden) ? "visible" : "hidden"));
 
-        // If yAxisOnClick present, attach to yAxis
-        if(yAxisHasOnClick){
-            yAxis.on("click", () => {
-                yAxisOnClick();
-            })
-            let label = document.getElementsByClassName(`tsi-swimLaneLabel-${agg.swimLane}`)[0];
-            if(label){
-                yAxis.on("mouseover", () => {
-                    label.classList.add("axisHover");
-                })
-                yAxis.on("mouseout", () => {
-                    label.classList.remove("axisHover");
-                })
-            }
-        }
         if (this.yAxisState.axisType === YAxisStates.Overlap) {
             yAxis.call(d3.axisLeft(aggY).tickFormat(Utils.formatYAxisNumber).tickValues(yExtent))
                 .selectAll("text")
@@ -148,6 +133,25 @@ class LinePlot extends Plot {
                 .ticks(Math.max(2, Math.ceil(this.height/(this.yAxisState.axisType === YAxisStates.Stacked ? this.visibleAggCount : 1)/90))))
                 .selectAll("text").classed("standardYAxisText", true)
         }
+
+        // If yAxisOnClick present, attach to yAxis
+        if(yAxisHasOnClick){
+            yAxis.on("click", () => {
+                yAxisOnClick();
+            })
+            let label = document.getElementsByClassName(`tsi-swimLaneLabel-${agg.swimLane}`)[0];
+            if(label){
+                yAxis.on("mouseover", () => {
+                    label.classList.add("axisHover");
+                    yAxis.selectAll("text").classed("boldYAxisText", true)
+                })
+                yAxis.on("mouseout", () => {
+                    label.classList.remove("axisHover");
+                    yAxis.selectAll("text").classed("boldYAxisText", false)
+                })
+            }
+        }
+
         yAxis.exit().remove();
         
         var guideLinesData = {

--- a/src/UXClient/Constants/Constants.ts
+++ b/src/UXClient/Constants/Constants.ts
@@ -16,3 +16,9 @@ export const DefaultHierarchyContextMenuOptions = {
 }
 
 export const nullTsidDisplayString = "null";
+
+export const swimlaneLabelConstants = {
+    leftMarginOffset: 40,
+    swimLaneLabelHeightPadding: 8,
+    labelLeftPadding: 28
+}

--- a/src/UXClient/Models/ChartOptions.ts
+++ b/src/UXClient/Models/ChartOptions.ts
@@ -5,6 +5,14 @@ import { Strings } from './Strings';
 import { DefaultHierarchyNavigationOptions } from '../Constants/Constants';
 import { InterpolationFunctions } from '../Constants/Enums';
 
+// Interfaces
+interface swimLaneOption {
+    yAxisType: YAxisStates, 
+    label?: string, 
+    onClick?: (lane: number) => any, 
+    collapseEvents?: string
+}
+
 class ChartOptions {
     public aggTopMargin: number; // margin on top of each aggregate line(s)
     public arcWidthRatio: number; // number between 0 and 1 which determines how thic the pie chart arc is
@@ -73,7 +81,7 @@ class ChartOptions {
     public shouldSticky: boolean; // whether sticky is triggered in the linechart when stickySeries or unStickySeries is called
     public strings: any; // passed in key value pairs of strings -> strings
     public suppressResizeListener: boolean; // whether a component's resize function is ignored. Applies to components which draw an SVG
-    public swimLaneOptions: {[key: number]: {yAxisType?: YAxisStates, label?: string, onClick?: (lane: number) => any, collapseEvents?: string}} | null;  // mapping of swim lane number to information about that swimlane, including axis type
+    public swimLaneOptions: {[key: number]: swimLaneOption} | null;  // mapping of swim lane number to information about that swimlane, including axis type
     public theme: string; // theme for styling chart, light or dark
     public timeFrame: any; // from and to to specify range of an event or state series
     public timestamp: any; //For components with a slider, this is the selected timestamp

--- a/src/UXClient/Models/ChartOptions.ts
+++ b/src/UXClient/Models/ChartOptions.ts
@@ -1,6 +1,6 @@
 import * as d3 from 'd3';
 import { quadtree } from 'd3';
-import Utils from '../Utils';
+import Utils, { YAxisStates } from '../Utils';
 import { Strings } from './Strings';
 import { DefaultHierarchyNavigationOptions } from '../Constants/Constants';
 import { InterpolationFunctions } from '../Constants/Enums';
@@ -73,7 +73,7 @@ class ChartOptions {
     public shouldSticky: boolean; // whether sticky is triggered in the linechart when stickySeries or unStickySeries is called
     public strings: any; // passed in key value pairs of strings -> strings
     public suppressResizeListener: boolean; // whether a component's resize function is ignored. Applies to components which draw an SVG
-    public swimLaneOptions: any;  // mapping of swim lane number to information about that swimlane, including axis type
+    public swimLaneOptions: {[key: number]: {yAxisType?: YAxisStates, label?: string, onClick?: (lane: number) => any, collapseEvents?: string}} | null;  // mapping of swim lane number to information about that swimlane, including axis type
     public theme: string; // theme for styling chart, light or dark
     public timeFrame: any; // from and to to specify range of an event or state series
     public timestamp: any; //For components with a slider, this is the selected timestamp


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/18181049/99302287-04c60a80-2804-11eb-957a-1f8c2e3cacee.png)

### Added swimlane labels
- Added label option to swimLaneOptions
- Added onClick option to swimLaneOptions
- Attached onClick to label (if present)
- Also attached onClick to swimlane y-Axis
- Added label hover state
- Added label title on long hover
- Added swimLaneLabels.html testcase

### Logic

The added code builds a map of swimLaneLabels by finding the first aggGroup in each swimLane, and using its `height` and `offset` values to position that lane's label.  This works because each numeric aggGroup sharing a lane will share the same  `height` and `offset` values.  Non-numeric aggGroups have additional logic to add their heights to the swimlane label height.  This ensures that the label is always vertically centered next to its lane.

- Each label is truncated based on: `height of its lane - 8px`
- Left margin is added to the chart when any label is present

### Testing
- Use swimLaneLabels.html testcase `/testcases/swimLanes/swimLaneLabels.html`
- Can build & install tsiclient tgz into T7, then add labels to swimLaneOptions when rendering linechart
