### PR TITLE
Hotfix for reverse lookup not working for tsids with special characters

### DIFF
--- a/pages/examples/testcases/instanceLookup.html
+++ b/pages/examples/testcases/instanceLookup.html
@@ -14,7 +14,7 @@
             margin-top: 20px;">
             <div>
                 <label>Time Series ID</label>
-                <p style="font-size: 12px;">- Use commas without space for composite tsid.</p>
+                <p style="font-size: 12px;">- Use | (vertical bar) without space between ids for composite tsid.</p>
                 <p style="font-size: 12px;">- Enter nothing for null tsid.</p>
                 <input id="timeSeriesId" type="text"/>
                 <button onclick="lookup()">Show</button>
@@ -147,7 +147,7 @@
 
             lookup = function() {
                 let value = document.getElementById("timeSeriesId").value;
-                let timeSeriesIdArray = value.split(",").map(id => {return id === "" ? null : id}); // use , for composite tsid's
+                let timeSeriesIdArray = value.split("|").map(id => {return id === "" ? null : id}); // use , for composite tsid's
                 hierarchy.showInstance(timeSeriesIdArray, /*["f25720a3-82ca-4cfe-a242-e047ac7d1de2", "c282f60a-d257-440b-836b-6dc275e9971b"]*/);
             }
         </script>

--- a/src/UXClient/Components/AvailabilityChart/AvailabilityChart.scss
+++ b/src/UXClient/Components/AvailabilityChart/AvailabilityChart.scss
@@ -249,7 +249,7 @@
     }
 
     .tsi-sparklineContainer {
-        background: none;
+        background: none !important;
         margin-top: -32px;
         path {
             stroke: none !important;

--- a/src/UXClient/Components/HierarchyNavigation/HierarchyNavigation.ts
+++ b/src/UXClient/Components/HierarchyNavigation/HierarchyNavigation.ts
@@ -446,7 +446,8 @@ class HierarchyNavigation extends Component{
      // do exact search with tsid to retrieve all possible paths until that instance to traverse for expansion
      private doExactSearchWithPossiblePaths = (tsid, hNames) => {
         this.setModeAndRequestParamsForFilter();
-        this.searchString = '"' + tsid.join(" ").replace(":", " ") + '"'; //TODO: null vs string null check for exact search and escape for character : fix from backend will come here!!
+        let escapedTsidString = tsid.join(" ").replaceAll(/[^a-zA-Z\d]/g, "+"); //escaping non alphanumeric characters with + for exact search with quotes
+        this.searchString = `"${escapedTsidString}"`; //TODO: null vs string null check for exact search and escape for character : fix from backend will come here!!
 
         return Promise.all(hNames.map(hName => {
             let payload = hName ? this.requestPayload([hName]) : this.requestPayload(null);

--- a/src/UXClient/Components/HierarchyNavigation/HierarchyNavigation.ts
+++ b/src/UXClient/Components/HierarchyNavigation/HierarchyNavigation.ts
@@ -446,7 +446,7 @@ class HierarchyNavigation extends Component{
      // do exact search with tsid to retrieve all possible paths until that instance to traverse for expansion
      private doExactSearchWithPossiblePaths = (tsid, hNames) => {
         this.setModeAndRequestParamsForFilter();
-        let escapedTsidString = tsid.join(" ").replaceAll(/["!\(\)\^\[\{:\]\}~/ @#\$%\&\*;'\+=._-]/g, '+'); //escaping non alphanumeric characters with + for exact search with quotes
+        let escapedTsidString = Utils.escapedTsidForExactSearch(tsid?.join(" "));
         this.searchString = `"${escapedTsidString}"`; //TODO: null vs string null check for exact search and escape for character : fix from backend will come here!!
 
         return Promise.all(hNames.map(hName => {
@@ -634,6 +634,7 @@ class HierarchyNavigation extends Component{
         } catch (err) { // errors are already catched by inner functions
             this.prepareComponentForAfterLookup();
             this.hierarchyElem.style('display', 'block');
+            this.noResultsElem.style('display', 'block');
             this.instanceLookupLoadingElem.style('display', 'none');
         }
     }

--- a/src/UXClient/Constants/Constants.ts
+++ b/src/UXClient/Constants/Constants.ts
@@ -16,3 +16,5 @@ export const DefaultHierarchyContextMenuOptions = {
 }
 
 export const nullTsidDisplayString = "null";
+
+export const CharactersToEscapeForExactSearchInstance = ['"', '`', '\'', '!', '(', ')', '^', '[', '{', ':', ']', '}', '~', '/', '\\', '@', '#', '$', '%', '&', '*', ';', '=', '.', '_', '-', '<', '>', ',', '?'];

--- a/src/UXClient/Utils.ts
+++ b/src/UXClient/Utils.ts
@@ -3,7 +3,7 @@ import moment from 'moment-timezone';
 import Grid from "./Components/Grid/Grid";
 import { ChartOptions } from './Models/ChartOptions';
 import { ChartComponentData } from './Models/ChartComponentData';
-import { nullTsidDisplayString } from './Constants/Constants';
+import { CharactersToEscapeForExactSearchInstance, nullTsidDisplayString } from './Constants/Constants';
 
 export const NONNUMERICTOPMARGIN = 8;
 export const LINECHARTTOPPADDING = 16;
@@ -1101,6 +1101,16 @@ class Utils {
             .classed(additionalClassName, options && options.additionalClassName)
             .text(d => d.str);
         children.exit().remove();
+    }
+
+    static escapedTsidForExactSearch = (tsid: string) => {
+        let escapedTsid = tsid || '';
+        if (tsid) {
+            CharactersToEscapeForExactSearchInstance.forEach(c => { //escaping some special characters with + for exact instance search in quotes
+                escapedTsid = escapedTsid.split(c).join('+');
+            });
+        }
+        return escapedTsid;
     }
 }
 


### PR DESCRIPTION
Per our discussion with backend folks, added escaping special characters with + in tsids for exact search in reverse lookup