### PR TITLE
Hotfix to prevent targetElement.classed() calls from breaking on null element

### DIFF
--- a/src/UXClient/Components/Marker/Marker.ts
+++ b/src/UXClient/Components/Marker/Marker.ts
@@ -393,6 +393,9 @@ class Marker extends Component {
                 let filteredValues = values.filter((v) => {
                     return (v.aggregateKey === aggKey && v.splitBy === splitBy && this.getValueOfVisible(v) !== null);
                 });
+                if (filteredValues.length === 0) {
+                    return;
+                }
                 if (filteredValues.length === 1 && (this.getValueOfVisible(filteredValues[0]) !== null)) {
                     valueArray.push(filteredValues[0]);
                 } else {

--- a/src/UXClient/Interfaces/Component.ts
+++ b/src/UXClient/Interfaces/Component.ts
@@ -21,10 +21,10 @@ class Component {
 	
 	protected themify(targetElement: any, theme: string){
 		var theme = Utils.getTheme(theme);
-		targetElement.classed(this.currentTheme, false);
-		targetElement.classed('tsi-light', false);
-		targetElement.classed('tsi-dark', false);
-		targetElement.classed(theme, true);
+		targetElement?.classed(this.currentTheme, false);
+		targetElement?.classed('tsi-light', false);
+		targetElement?.classed('tsi-dark', false);
+		targetElement?.classed(theme, true);
 		this.currentTheme = theme;
 	}
 


### PR DESCRIPTION
- Added optional chaining to themify block to only apply class names if target element is truthy