### PR TITLE
Fixes for null/interpolated values and left offset in markers/series labels

### DIFF
--- a/src/UXClient/Components/Marker/Marker.ts
+++ b/src/UXClient/Components/Marker/Marker.ts
@@ -392,9 +392,6 @@ class Marker extends Component {
                 let filteredValues = values.filter((v) => {
                     return (v.aggregateKey === aggKey && v.splitBy === splitBy && this.getValueOfVisible(v) !== null);
                 });
-                if (filteredValues.length === 0) {
-                    return;
-                }
                 if (filteredValues.length === 1 && (this.getValueOfVisible(filteredValues[0]) !== null)) {
                     valueArray.push(filteredValues[0]);
                 } else {
@@ -403,7 +400,9 @@ class Marker extends Component {
                         valueArray.push(interpolatedValue);
                     } else {
                         let lastValue = this.chartComponentData.findLastTimestampWithValue(aggKey, splitBy);
-                        valueArray.push(this.chartComponentData.findLastTimestampWithValue(aggKey, splitBy));
+                        if (lastValue !== null) {
+                            valueArray.push(lastValue);
+                        }
                     }
                 }
             });
@@ -445,7 +444,7 @@ class Marker extends Component {
                 let tooltipHeight = MARKERVALUENUMERICHEIGHT;
                 tooltip.draw(d, self.chartComponentData, 0, MARKERVALUENUMERICHEIGHT/2, {right:0, left:0, top:0, bottom:0}, (tooltipTextElement) => {
                     self.tooltipFormat(d, tooltipTextElement, null, null);
-                }, null, 0, 0, self.colorMap[d.aggregateKey + "_" + d.splitBy], false);
+                }, null, 0, 0, self.colorMap[d.aggregateKey + "_" + d.splitBy], true);
 
                 let markerValueCaret = d3.select(this).selectAll('.tsi-markerValueCaret')
                     .data([d]);

--- a/src/UXClient/Components/Tooltip/Tooltip.ts
+++ b/src/UXClient/Components/Tooltip/Tooltip.ts
@@ -74,13 +74,13 @@ class Tooltip extends Component {
         
         // Element width is an optional parameter which ensures that the tooltip doesn't interfere with the element
         // when positioning to the right
-        this.draw = (d: any, chartComponentData: ChartComponentData, xPos, yPos, chartMargins, addText, elementWidth: number = null, xOffset = 20, yOffset = 20, borderColor: string = null, shouldYPosBeBounded: boolean = true) => {
+        this.draw = (d: any, chartComponentData: ChartComponentData, xPos, yPos, chartMargins, addText, elementWidth: number = null, xOffset = 20, yOffset = 20, borderColor: string = null, isFromMarker: boolean = false) => {
             this.tooltipDiv.style("display", "block"); 
             this.tooltipDivInner.text(null);
 
             this.borderColor = borderColor;
 
-            var leftOffset = this.getLeftOffset(chartMargins);
+            var leftOffset = isFromMarker ? 0 : this.getLeftOffset(chartMargins);
             var topOffset = this.getTopOffset(chartMargins);
             addText(this.tooltipDivInner);
 
@@ -98,7 +98,7 @@ class Tooltip extends Component {
             if(this.isTopOffset(tooltipHeight, yPos, chartMargins)){ // Place tooltip @ bottom of point
                 translateY = yOffset;
             } else{
-                if(shouldYPosBeBounded && Math.round(yPos) - yOffset + topOffset - Math.round(tooltipHeight) <= 0){ // Upper bound check to keep tooltip within chart
+                if(!isFromMarker && Math.round(yPos) - yOffset + topOffset - Math.round(tooltipHeight) <= 0){ // Upper bound check to keep tooltip within chart
                     translateY = -(Math.round(yPos) + topOffset);
                 }else{
                     translateY = (-Math.round(tooltipHeight) - yOffset); // Place tooltip @ top of point


### PR DESCRIPTION
reverted bad fix for null values in series labels, replaced with fix that actually allows interpolated values, and changed parameter from shouldYPosBeBounded to isFromMarker in tooltip to allow for fix in setting left offset