### PR TITLE
Negative height bugfix

### DIFF
--- a/src/UXClient/Components/AvailabilityChart/AvailabilityChart.ts
+++ b/src/UXClient/Components/AvailabilityChart/AvailabilityChart.ts
@@ -398,7 +398,7 @@ class AvailabilityChart extends ChartComponent{
                 warmRect.attr("x", Math.max(this.timePickerLineChart.x(boundedWarmStart)))
                     .attr("y", this.chartOptions.isCompact ? 12 : -8)
                     .attr("width", this.timePickerLineChart.x(boundedWarmEnd) - this.timePickerLineChart.x(boundedWarmStart))
-                    .attr("height", this.chartOptions.isCompact ? 4 : (this.targetElement.select('.tsi-timePickerContainer').select(".tsi-lineChartSVG").node().getBoundingClientRect().height - 44))
+                    .attr("height", this.chartOptions.isCompact ? 4 : Math.max((this.targetElement.select('.tsi-timePickerContainer').select(".tsi-lineChartSVG").node().getBoundingClientRect().height - 44), 0))
                     .attr("fill-opacity", this.chartOptions.isCompact ? .8 : .08)
                     .attr('stroke-opacity', this.chartOptions.isCompact ? 0 : .5)
                     .attr("pointer-events", "none");

--- a/src/UXClient/Components/CategoricalPlot/CategoricalPlot.ts
+++ b/src/UXClient/Components/CategoricalPlot/CategoricalPlot.ts
@@ -25,7 +25,7 @@ class CategoricalPlot extends Plot {
                 return this.x(new Date(d.dateTime))
             })
             .attr('width', rectWidth)
-            .attr('height', this.chartHeight + 1 - LINECHARTTOPPADDING)
+            .attr('height', Math.max(0, this.chartHeight + 1 - LINECHARTTOPPADDING))
             .attr('fill', () => {
                 return visibleMeasures.length === 1 ? this.getColorForValue(visibleMeasures[0]) : 'none'
             });

--- a/src/UXClient/Components/HeatmapCanvas/HeatmapCanvas.ts
+++ b/src/UXClient/Components/HeatmapCanvas/HeatmapCanvas.ts
@@ -63,7 +63,7 @@ class HeatmapCanvas extends ChartComponent {
             .attr("x", this.legendWidth - this.gradientWidth)
             .attr("y", 6)
             .attr("width", this.gradientWidth)
-            .attr("height", this.height - 12)
+            .attr("height", Math.max(0, this.height - 12))
             .style("fill", "url(#gradient" + String(this.aggI) + gradientGuid + ")");
 
         var highlightedValueY = null;

--- a/src/UXClient/Components/LineChart/LineChart.ts
+++ b/src/UXClient/Components/LineChart/LineChart.ts
@@ -1655,7 +1655,7 @@ class LineChart extends TemporalXAxisComponent {
                 if (this.brushElem) {
                     var self = this;
                     this.brush = d3.brushX()
-                    .extent([[this.xLowerBound, this.chartOptions.aggTopMargin],
+                    .extent([[this.xLowerBound, Math.min(this.chartHeight, this.chartOptions.aggTopMargin)],
                              [this.xUpperBound, this.chartHeight]])
                     .on("start", function() {
                         if (self.activeMarker !== null && self.isDroppingMarker) {


### PR DESCRIPTION
Fix for `Error: <rect> attribute height: A negative value is not valid.` errors
![image](https://user-images.githubusercontent.com/18181049/102290405-d8caa180-3ef5-11eb-8434-08870375a3f3.png)

## Fix
Added Math.min/max logic to prevent height attribute from ever receiving negative values on resize