### PR TITLE
Hotfix for values with same timestamp

### DIFF
--- a/src/UXClient/UXClient.ts
+++ b/src/UXClient/UXClient.ts
@@ -183,7 +183,9 @@ class UXClient {
                 transformedAggregate[''] = {};
             else{
                 tsqr.timestamps.forEach((ts, j) => {
-                    aggregatesObject[ts] = tsqr.properties.reduce((p,c) => {p[c.name] = c['values'][j]; return p;}, {});
+                    aggregatesObject[ts] = tsqr.properties.reduce((p,c) => { // there can be multiple values for the same timestamp for a property, here we keep the latest non-null value if exist
+                        p[c.name] = aggregatesObject[ts] && aggregatesObject[ts][c.name] !== null ? aggregatesObject[ts][c.name] : c['values'][j]; return p;
+                    }, {});
                 }); 
             }
             result.push(transformedAggregate);


### PR DESCRIPTION
If there are different values for the same timestamp, pick and preserve the non-null one