### PR TITLE
HierarchyNodeOptions added to support custom context menu for hierarchy nodes

### DIFF
--- a/pages/examples/testcases/customContextMenuInHierarchy.html
+++ b/pages/examples/testcases/customContextMenuInHierarchy.html
@@ -1,0 +1,149 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <!-- styles are only used for styling header and auth elements, where possible -->
+        <link rel="stylesheet" type="text/css" href="../styles.css" />
+        <title>Custom Context Menu in Hierarchy Navigation</title>
+    </head>
+    <body style="font-family: 'Segoe UI', sans-serif;">
+        <div id="hierarchyNav" style="
+                width: 308px;
+                height: calc(100% - 40px);
+                position: fixed;top: 40px;">
+        </div>
+        <script>
+            var hierarchy;
+            var environmentFqdn = '6988946f-2b5c-4f84-9921-530501fbab45.env.timeseries.azure.com';
+            var tsiClient;
+            onInstanceClick = function(instance) {
+                let contextMenuActions = [];
+                authContext.getTsiToken().then(token => { //TODO: change this to Observable with Observable.from with .takeUntil(Observable.of(true).delay(2000)) to return default type variables, or maybe move this onclick into HierarchyNavigation component using rxjs lib
+                    tsiClient.server.getTimeseriesTypes(token, environmentFqdn, [instance.type.id]).then(r => {
+                        if (r.get && Array.isArray(r.get)) {
+                            r.get.forEach((t) => {
+                                let type = t.timeSeriesType;
+                                Object.keys(type.variables).forEach((vName) => {
+                                    let option = {};
+                                    if (type.variables[vName].aggregation && type.variables[vName].aggregation.tsx === 'avg($value)') {
+                                        let newType = this.getTsmTypeFromVariable(type.variables[vName]);
+                                        option.name = vName;
+                                        option.kind = type.variables[vName].kind;
+                                        option.action = () => alert(JSON.stringify(newType.variables));
+                                    } else {
+                                        option.name = vName;
+                                        option.kind = type.variables[vName].kind;
+                                        option.action = () => alert(JSON.stringify(type.variables));//addInstanceAction(type, vName);
+                                    }
+                                    contextMenuActions.push(option);
+                                });
+                            });
+                            hierarchy.drawContextMenu(contextMenuActions, {
+                                isSelectionEnabled: contextMenuActions.length > 1 ? true : false, 
+                                isFilterEnabled: contextMenuActions.length > 5 ? true : false,
+                                onClose: () => hierarchy.closeContextMenu()
+                            });
+                        }
+                    }).catch(function (err) {
+                        let typeVariables = instance.type.variables;
+                        
+                        Object.keys(typeVariables).forEach((vName) => {
+                            let option = {};
+                            if (typeVariables[vName].aggregation && typeVariables[vName].aggregation.tsx === 'avg($value)') {
+                                let newType = this.getTsmTypeFromVariable(typeVariables[vName]);
+                                option.name = vName;
+                                option.kind = typeVariables[vName].kind;
+                                option.action = () => alert(JSON.stringify(newType.variables));
+                            } else {
+                                option.name = vName;
+                                option.kind = typeVariables[vName].kind;
+                                option.action = () => alert(JSON.stringify(instance.type.variables));//addInstanceAction(type, vName);
+                            }
+                            contextMenuActions.push(option);
+                        });
+                        hierarchy.drawContextMenu(contextMenuActions, {
+                            isSelectionEnabled: contextMenuActions.length > 1 ? true : false, 
+                            isFilterEnabled: contextMenuActions.length > 5 ? true : false
+                        });
+                    });
+                });
+            }
+
+            onHierarchyNodeClick = function(hierarchy, path) {
+                console.log("Hierarchy: " + hierarchy);
+                path.forEach(p => {
+                    console.log("Instance Field: " + JSON.stringify(p));
+                });
+            }
+
+            getTsmTypeFromVariable = (v) => {
+                let type = {variables: {
+                    avg: 
+                        {kind: 'numeric', 
+                        value: v.value, 
+                        filter: v.filter ? v.filter : null, 
+                        aggregation: {
+                            tsx: 'avg($value)'
+                            }
+                        }
+                    ,
+                    min: 
+                        {kind: 'numeric', 
+                        value: v.value, 
+                        filter: v.filter ? v.filter : null, 
+                        aggregation: {
+                            tsx: 'min($value)'
+                            }
+                        }
+                    ,
+                    max: 
+                        {kind: 'numeric', 
+                        value: v.value, 
+                        filter: v.filter ? v.filter : null,
+                        aggregation: {
+                            tsx: 'max($value)'
+                            }
+                        }
+                }};
+                return type;
+            }
+
+            var hierarchyNavOptions = {
+                theme: 'light',
+                hierarchyOptions: {
+                    instancesPageSize: 10,
+                    hierarchiesPageSize: 10,
+                    isInstancesRecursive: false,
+                    isInstancesHighlighted: true,
+                    instancesSort: "DisplayName",
+                    hierarchiesExpand: "OneLevel",
+                    hierarchiesSort: "Name"
+                }
+            }
+
+            toggleHierarchyNavigationOption = function(property, value = null) {
+                hierarchyNavOptions[property] = (value === null) ? !hierarchyNavOptions[property] : value; 
+                hierarchy.render(environmentFqdn, authContext.getTsiToken, Object.assign({}, hierarchyNavOptions, {
+                    onInstanceClick: instance => this.onInstanceClick(instance),
+                    onHierarchyNodeClick: (hierarchy, path) => this.onHierarchyNodeClick(hierarchy, path)
+                }));
+            }
+
+            window.onload = function() {
+                initAuth('Custom Context Menu in Hierarchy Navigation');  // initiate auth objects, header, and login modal
+                tsiClient = new TsiClient();
+                
+                hierarchy = new tsiClient.ux.HierarchyNavigation(document.getElementById('hierarchyNav'));
+                hierarchy.render(environmentFqdn, authContext.getTsiToken, Object.assign({}, hierarchyNavOptions, {
+                    onInstanceClick: instance => this.onInstanceClick(instance),
+                    onHierarchyNodeClick: (hierarchy, path) => this.onHierarchyNodeClick(hierarchy, path)
+                }));
+
+            }
+        </script>
+    </body>
+    <!-- boilerplate headers are injected with head.js, grab them from the live example header, or include a link to head.js -->
+    <script src="../boilerplate/head.js"></script>
+
+    <!-- boilerplate auth code is injected with auth.js, check it out for auth setup -->
+    <script src="../boilerplate/auth.js"></script>
+</html>

--- a/pages/examples/testcases/customContextMenuInHierarchy.html
+++ b/pages/examples/testcases/customContextMenuInHierarchy.html
@@ -4,6 +4,16 @@
         <!-- styles are only used for styling header and auth elements, where possible -->
         <link rel="stylesheet" type="text/css" href="../styles.css" />
         <title>Custom Context Menu in Hierarchy Navigation</title>
+
+        <style>
+            .boat-icon {
+                background-image: url(../images/boat.png);
+            }
+
+            .vat-icon {
+                background-image: url(../images/vat.png);
+            }
+        </style>
     </head>
     <body style="font-family: 'Segoe UI', sans-serif;">
         <div id="hierarchyNav" style="
@@ -68,6 +78,14 @@
                 });
             }
 
+            hierarchyNodeOptions = function(hierarchy, path) {
+                return {
+                    iconClass: "vat-icon",
+                    iconLabel: "Create fleet query",
+                    onHierarchyNodeClick: onHierarchyNodeClick
+                }
+            }
+
             onHierarchyNodeClick = function(hierarchy, path) {
                 console.log("Hierarchy: " + hierarchy);
                 path.forEach(p => {
@@ -120,22 +138,14 @@
                 }
             }
 
-            toggleHierarchyNavigationOption = function(property, value = null) {
-                hierarchyNavOptions[property] = (value === null) ? !hierarchyNavOptions[property] : value; 
-                hierarchy.render(environmentFqdn, authContext.getTsiToken, Object.assign({}, hierarchyNavOptions, {
-                    onInstanceClick: instance => this.onInstanceClick(instance),
-                    onHierarchyNodeClick: (hierarchy, path) => this.onHierarchyNodeClick(hierarchy, path)
-                }));
-            }
-
             window.onload = function() {
-                initAuth('Custom Context Menu in Hierarchy Navigation');  // initiate auth objects, header, and login modal
+                initAuth('Custom Context Menu in Hierarchy');  // initiate auth objects, header, and login modal
                 tsiClient = new TsiClient();
                 
                 hierarchy = new tsiClient.ux.HierarchyNavigation(document.getElementById('hierarchyNav'));
                 hierarchy.render(environmentFqdn, authContext.getTsiToken, Object.assign({}, hierarchyNavOptions, {
-                    onInstanceClick: instance => this.onInstanceClick(instance),
-                    onHierarchyNodeClick: (hierarchy, path) => this.onHierarchyNodeClick(hierarchy, path)
+                    onInstanceClick: instance => onInstanceClick(instance),
+                    hierarchyNodeOptions: hierarchyNodeOptions
                 }));
 
             }

--- a/src/UXClient/Components/HierarchyNavigation/HierarchyNavigation.scss
+++ b/src/UXClient/Components/HierarchyNavigation/HierarchyNavigation.scss
@@ -189,6 +189,10 @@
             background-image: url(../../Icons/Filter_Icon_Dark_Theme.svg);
         }
 
+        .tsi-stacked-icon {
+            background-image: url(../../Icons/stacked.svg);
+        }
+
         .tsi-spinner-icon {
             background-image: url(../../Icons/Spinner.svg);
         }
@@ -221,6 +225,10 @@
 
         .tsi-filter-icon {
             background-image: url(../../Icons/Filter_Icon_Light_Theme.svg);
+        }
+
+        .tsi-stacked-icon {
+            background-image: url(../../Icons/stacked.svg);
         }
 
         .tsi-spinner-icon {
@@ -351,13 +359,6 @@
             align-items: center;
             flex-direction: row;
             padding: 0;
-
-            .tsi-filter-icon {
-                width: 12px;
-                height: 10px;
-                cursor: auto;
-                margin-right: 4px;
-            }
     
             .tsi-path-list {
                 display: flex;
@@ -511,7 +512,7 @@
         }
     }
 
-    .tsi-filter-icon {
+    .tsi-filter-icon, .tsi-stacked-icon {
         z-index: 3 !important;
         right: 20px;
         position: absolute;
@@ -523,6 +524,10 @@
         background-size: 11px;
         background-position: center;
         top: 6px;
+    }
+
+    .tsi-stacked-icon {
+        right: 40px;
     }
 
     .tsi-down-caret-icon {

--- a/src/UXClient/Components/HierarchyNavigation/HierarchyNavigation.scss
+++ b/src/UXClient/Components/HierarchyNavigation/HierarchyNavigation.scss
@@ -71,13 +71,11 @@
             outline: none;
         }
     }
-    .tsi-leaf {
-        &.tsi-selected {
-            background: $gray2;
-            .tsi-hierarchyItem{
-                &:hover{
-                    background: $gray2;
-                }
+    .tsi-selected {
+        background: $gray2;
+        .tsi-hierarchyItem{
+            &:hover{
+                background: $gray2;
             }
         }
     }
@@ -189,10 +187,6 @@
             background-image: url(../../Icons/Filter_Icon_Dark_Theme.svg);
         }
 
-        .tsi-stacked-icon {
-            background-image: url(../../Icons/stacked.svg);
-        }
-
         .tsi-spinner-icon {
             background-image: url(../../Icons/Spinner.svg);
         }
@@ -225,10 +219,6 @@
 
         .tsi-filter-icon {
             background-image: url(../../Icons/Filter_Icon_Light_Theme.svg);
-        }
-
-        .tsi-stacked-icon {
-            background-image: url(../../Icons/stacked.svg);
         }
 
         .tsi-spinner-icon {
@@ -512,7 +502,7 @@
         }
     }
 
-    .tsi-filter-icon, .tsi-stacked-icon {
+    .tsi-filter-icon, .tsi-hierarchy-node-custom-icon {
         z-index: 3 !important;
         right: 20px;
         position: absolute;
@@ -526,7 +516,7 @@
         top: 6px;
     }
 
-    .tsi-stacked-icon {
+    .tsi-hierarchy-node-custom-icon {
         right: 40px;
     }
 

--- a/src/UXClient/Components/HierarchyNavigation/HierarchyNavigation.ts
+++ b/src/UXClient/Components/HierarchyNavigation/HierarchyNavigation.ts
@@ -6,12 +6,38 @@ import ServerClient from '../../../ServerClient/ServerClient';
 import ModelAutocomplete from '../ModelAutocomplete/ModelAutocomplete';
 import { KeyCodes, InstancesSort, HierarchiesExpand, HierarchiesSort } from '../../Constants/Enums';
 
+interface ContextMenuItems {
+    name: string,
+    kind: string,
+    action: any
+};
+
+interface ContextMenuOptions {
+    isSelectionEnabled: boolean,
+    isFilterEnabled: boolean,
+    onClose: any
+};
+
+export interface HierarchyNodeOptions {
+    iconClass: string,
+    iconLabel: string,
+    onHierarchyNodeClick: (hierarchyName: string, path: Array<HierarchyNodePath>) => any
+};
+
+export interface HierarchyNodePath {
+    instanceFieldName: string,
+    instanceFieldValue: string
+}
+
+export enum HierarchySelectionValues {All = "0", Unparented = "-1"};
+export enum ViewType {Hierarchy, List};
+export enum State {Navigate, Search, Filter};
 
 class HierarchyNavigation extends Component{
     private server: ServerClient;
     private getToken;
     private environmentFqdn;
-    private clickedInstance;
+    private clickedHierarchyItem;
     private isHierarchySelectionActive;
     private hierarchySelectorElem;
     private filterPathElem;
@@ -44,7 +70,7 @@ class HierarchyNavigation extends Component{
             return d3.event.target === this || this.contains(d3.event.target);
         }
         d3.select("html").on("click. keydown." + Utils.guid(), () => { //close hierarchy selection dropdown or context menu if necessary 
-            if (this.clickedInstance && this.contextMenu) {
+            if (this.clickedHierarchyItem && this.contextMenu) {
                 if (d3.event.type && d3.event.type === 'keydown') {
                     if (!this.contextMenu.filter(isTarget).empty()) {
                         let key = d3.event.which || d3.event.keyCode;
@@ -903,23 +929,25 @@ class HierarchyNavigation extends Component{
     }
 
     public closeContextMenu = () => {
-        if(this.clickedInstance && this.contextMenu) {
-            this.contextMenu.remove();
+        if (this.clickedHierarchyItem) {
+            if (this.contextMenu) {
+                this.contextMenu.remove();
+            }
             d3.selectAll('li.tsi-selected').classed('tsi-selected', false);
         }
         d3.selectAll('.tsi-modelResultWrapper').classed('tsi-selected', false);
-        this.clickedInstance = null;
+        this.clickedHierarchyItem = null;
     }
 
-    private prepareForContextMenu = (instanceObj, target, wrapperMousePos, eltMousePos) => {
+    private prepareForContextMenu = (hierarchyItem, target, wrapperMousePos, eltMousePos) => {
         let contextMenuProps = {};
         contextMenuProps['target'] = target;
         contextMenuProps['wrapperMousePos'] = wrapperMousePos;
         contextMenuProps['eltMousePos'] = eltMousePos;
         this.contextMenuProps = contextMenuProps;
 
-        this.clickedInstance = instanceObj;
-        instanceObj.node.classed('tsi-selected', true);
+        this.clickedHierarchyItem = hierarchyItem;
+        hierarchyItem.node.classed('tsi-selected', true);
     }
 
     public drawContextMenu = (contextMenuItems: Array<ContextMenuItems>, contextMenuOptions: ContextMenuOptions) => {
@@ -1035,6 +1063,7 @@ class HierarchyNavigation extends Component{
                     self.prepareForContextMenu(hORi, target, mouseWrapper[1], mouseElt[1]);
                     self.chartOptions.onInstanceClick(hORi);
                 } else {
+                    self.closeContextMenu();
                     if (hORi.isExpanded) {
                         hORi.collapse();
                     } else {
@@ -1046,7 +1075,9 @@ class HierarchyNavigation extends Component{
                 if (isHierarchyNode) {
                     if (d3.event.relatedTarget != d3.select(this.parentNode).select('.tsi-filter-icon').node()) {
                         (d3.select(this.parentNode).select('.tsi-filter-icon').node() as any).style.visibility = 'visible';
-                        (d3.select(this.parentNode).select('.tsi-stacked-icon').node() as any).style.visibility = 'visible';
+                        if (self.chartOptions.hierarchyNodeOptions) {
+                            (d3.select(this.parentNode).select('.tsi-hierarchy-node-custom-icon').node() as any).style.visibility = 'visible';
+                        }
                     }
                 }
             })
@@ -1054,7 +1085,9 @@ class HierarchyNavigation extends Component{
                 if (isHierarchyNode) {
                     if (d3.event.relatedTarget != d3.select(this.parentNode).select('.tsi-filter-icon').node()) {
                         (d3.select(this.parentNode).select('.tsi-filter-icon').node() as any).style.visibility = 'hidden';
-                        (d3.select(this.parentNode).select('.tsi-stacked-icon').node() as any).style.visibility = 'hidden';
+                        if (self.chartOptions.hierarchyNodeOptions) {
+                            (d3.select(this.parentNode).select('.tsi-hierarchy-node-custom-icon').node() as any).style.visibility = 'hidden';
+                        }
                     }
                 }
             });
@@ -1100,27 +1133,38 @@ class HierarchyNavigation extends Component{
                         (this as any).style.visibility = 'hidden';
                     }
                 });
-            if (self.chartOptions.onHierarchyNodeClick) {
-                hierarchyItemElem.append('div').classed('tsi-stacked-icon', true).attr('title', this.getString('Build fleet query'))
-                .attr('tabindex', 0)
-                .attr('arialabel', this.getString('Build fleet query'))
-                .attr('role', 'button')
-                .on('click keydown', function() {
-                    if (Utils.isKeyDownAndNotEnter(d3.event)) {return; }
-                    d3.event.preventDefault();
-                    d3.event.stopPropagation();
-                    let path = [];
-                    hORi.path.forEach((p, idx) => {
-                        if (idx === 0) return;
-                        let property = {instanceFieldName: self.envHierarchies[hORi.path[0]].source.instanceFieldNames[idx-1], instanceFieldValue: p};
-                        path.push(property);
-                    });
-                    self.chartOptions.onHierarchyNodeClick(self.selectedHierarchyName === HierarchySelectionValues.All || self.selectedHierarchyName === HierarchySelectionValues.Unparented ? hORi.path[0] : self.selectedHierarchyName, path);
-                }).on('mouseleave blur', function() {
-                    if (d3.event.relatedTarget != d3.select((this as HTMLElement).parentNode)) {
-                        (this as any).style.visibility = 'hidden';
-                    }
+            if (self.chartOptions.hierarchyNodeOptions) {
+                let hierarchyName = this.selectedHierarchyName === HierarchySelectionValues.All || this.selectedHierarchyName === HierarchySelectionValues.Unparented ? hORi.path[0] : this.selectedHierarchyName;
+                let path = [];
+                hORi.path.forEach((p, idx) => {
+                    if (idx === 0) return;
+                    let property = {instanceFieldName: this.envHierarchies[hORi.path[0]].source.instanceFieldNames[idx-1], instanceFieldValue: p};
+                    path.push(property);
                 });
+
+                let options = self.chartOptions.hierarchyNodeOptions(hierarchyName, path);
+
+                hierarchyItemElem.append('div').classed('tsi-hierarchy-node-custom-icon', true)
+                    .classed(options.iconClass, true)
+                    .attr('title', options.iconLabel)
+                    .attr('tabindex', 0)
+                    .attr('arialabel', options.iconLabel)
+                    .attr('role', 'button')
+                    .on('click keydown', function() {
+                        if (Utils.isKeyDownAndNotEnter(d3.event)) {return; }
+                        d3.event.preventDefault();
+                        d3.event.stopPropagation();
+                        self.closeContextMenu();
+                        let mouseElt = d3.mouse(this as any);
+                        let target = self.hierarchyElem.select(function() { return this.parentNode});
+                        let mouseWrapper = d3.mouse(target.node());
+                        self.prepareForContextMenu(hORi, target, mouseWrapper[1], mouseElt[1]);
+                        options.onHierarchyNodeClick(hierarchyName, path);
+                    }).on('mouseleave blur', function() {
+                        if (d3.event.relatedTarget != d3.select((this as HTMLElement).parentNode)) {
+                            (this as any).style.visibility = 'hidden';
+                        }
+                    });
             }
         } else {
             let spanElem = hierarchyItemElem.append('span').classed('tsi-name', true);
@@ -1268,7 +1312,7 @@ class HierarchyNavigation extends Component{
         this.envTypes = {};
         this.setModeAndRequestParamsForNavigate();
         this.viewType = ViewType.Hierarchy;
-        this.clickedInstance = null;
+        this.clickedHierarchyItem = null;
         this.isHierarchySelectionActive = false;
     }
 }
@@ -1296,21 +1340,5 @@ function InstanceNode (tsId, name = null, type, hierarchyIds, highlights, level)
     this.level = level;
     this.node = null;
 }
-
-interface ContextMenuItems {
-    name: string,
-    kind: string,
-    action: any
-};
-
-interface ContextMenuOptions {
-    isSelectionEnabled: boolean,
-    isFilterEnabled: boolean,
-    onClose: any
-};
-
-export enum HierarchySelectionValues {All = "0", Unparented = "-1"};
-export enum ViewType {Hierarchy, List};
-export enum State {Navigate, Search, Filter};
 
 export default HierarchyNavigation

--- a/src/UXClient/Components/HierarchyNavigation/HierarchyNavigation.ts
+++ b/src/UXClient/Components/HierarchyNavigation/HierarchyNavigation.ts
@@ -1046,6 +1046,7 @@ class HierarchyNavigation extends Component{
                 if (isHierarchyNode) {
                     if (d3.event.relatedTarget != d3.select(this.parentNode).select('.tsi-filter-icon').node()) {
                         (d3.select(this.parentNode).select('.tsi-filter-icon').node() as any).style.visibility = 'visible';
+                        (d3.select(this.parentNode).select('.tsi-stacked-icon').node() as any).style.visibility = 'visible';
                     }
                 }
             })
@@ -1053,6 +1054,7 @@ class HierarchyNavigation extends Component{
                 if (isHierarchyNode) {
                     if (d3.event.relatedTarget != d3.select(this.parentNode).select('.tsi-filter-icon').node()) {
                         (d3.select(this.parentNode).select('.tsi-filter-icon').node() as any).style.visibility = 'hidden';
+                        (d3.select(this.parentNode).select('.tsi-stacked-icon').node() as any).style.visibility = 'hidden';
                     }
                 }
             });
@@ -1098,6 +1100,28 @@ class HierarchyNavigation extends Component{
                         (this as any).style.visibility = 'hidden';
                     }
                 });
+            if (self.chartOptions.onHierarchyNodeClick) {
+                hierarchyItemElem.append('div').classed('tsi-stacked-icon', true).attr('title', this.getString('Build fleet query'))
+                .attr('tabindex', 0)
+                .attr('arialabel', this.getString('Build fleet query'))
+                .attr('role', 'button')
+                .on('click keydown', function() {
+                    if (Utils.isKeyDownAndNotEnter(d3.event)) {return; }
+                    d3.event.preventDefault();
+                    d3.event.stopPropagation();
+                    let path = [];
+                    hORi.path.forEach((p, idx) => {
+                        if (idx === 0) return;
+                        let property = {instanceFieldName: self.envHierarchies[hORi.path[0]].source.instanceFieldNames[idx-1], instanceFieldValue: p};
+                        path.push(property);
+                    });
+                    self.chartOptions.onHierarchyNodeClick(self.selectedHierarchyName === HierarchySelectionValues.All || self.selectedHierarchyName === HierarchySelectionValues.Unparented ? hORi.path[0] : self.selectedHierarchyName, path);
+                }).on('mouseleave blur', function() {
+                    if (d3.event.relatedTarget != d3.select((this as HTMLElement).parentNode)) {
+                        (this as any).style.visibility = 'hidden';
+                    }
+                });
+            }
         } else {
             let spanElem = hierarchyItemElem.append('span').classed('tsi-name', true);
             Utils.appendFormattedElementsFromString(spanElem, this.instanceNodeStringToDisplay(hORi));

--- a/src/UXClient/Models/ChartOptions.ts
+++ b/src/UXClient/Models/ChartOptions.ts
@@ -13,6 +13,11 @@ interface swimLaneOption {
     collapseEvents?: string
 }
 
+interface hierarchyNodePath {
+    instanceFieldName: string,
+    instanceFieldValue: string
+}
+
 class ChartOptions {
     public aggTopMargin: number; // margin on top of each aggregate line(s)
     public arcWidthRatio: number; // number between 0 and 1 which determines how thic the pie chart arc is
@@ -62,6 +67,7 @@ class ChartOptions {
     public onClick: (d3Event: any) => void; // for handling click, e.g. clicking on color picker
     public onInput: (searchText: string, event) => void; // for handling after input actions in ModelAutocomplete
     public onInstanceClick: (instance: any) => any;  // for model search, takes an instance and returns an object of context menu actions
+    public onHierarchyNodeClick: (hierarchyName: string, path: Array<hierarchyNodePath>) => any; // takes the path to that node when you click on a non-leaf/non-instance hierarchy node to trigger a custom context menu for fleet query etc.
     public onKeydown: (d3Event: any, awesompleteObject: any) => void;  // for handling keydown actions in ModelAutocomplete
     public onMarkersChange: (markers: Array<number>) => any; //triggered when a marker is either added or removed in the linechart
     public onMouseout: () => void;
@@ -174,6 +180,7 @@ class ChartOptions {
         this.includeTimezones = this.mergeValue(chartOptionsObj, 'includeTimezones', true);
         this.availabilityLeftMargin = this.mergeValue(chartOptionsObj, 'availabilityLeftMargin', 60);
         this.onInstanceClick = this.mergeValue(chartOptionsObj, 'onInstanceClick', () => {return {}});
+        this.onHierarchyNodeClick = this.mergeValue(chartOptionsObj, 'onHierarchyNodeClick', () => {});
         this.interpolationFunction = this.getInterpolationFunction(this.mergeValue(chartOptionsObj, 'interpolationFunction', InterpolationFunctions.None));
         this.includeEnvelope = this.mergeValue(chartOptionsObj, 'includeEnvelope', false);
         this.canDownload = this.mergeValue(chartOptionsObj, 'canDownload', true);
@@ -272,6 +279,7 @@ class ChartOptions {
             includeTimezones: this.includeTimezones,
             availabilityLeftMargin: this.availabilityLeftMargin,
             onInstanceClick: this.onInstanceClick,
+            onHierarchyNodeClick: this.onHierarchyNodeClick,
             interpolationFunction: this.interpolationFunction,
             includeEnvelope: this.includeEnvelope,
             canDownload: this.canDownload,

--- a/src/UXClient/Models/ChartOptions.ts
+++ b/src/UXClient/Models/ChartOptions.ts
@@ -6,14 +6,14 @@ import { DefaultHierarchyNavigationOptions } from '../Constants/Constants';
 import { InterpolationFunctions } from '../Constants/Enums';
 
 // Interfaces
-interface swimLaneOption {
+interface SwimLaneOption {
     yAxisType: YAxisStates, 
     label?: string, 
     onClick?: (lane: number) => any, 
     collapseEvents?: string
 }
 
-interface hierarchyNodePath {
+interface HierarchyNodePath {
     instanceFieldName: string,
     instanceFieldValue: string
 }
@@ -87,7 +87,7 @@ class ChartOptions {
     public shouldSticky: boolean; // whether sticky is triggered in the linechart when stickySeries or unStickySeries is called
     public strings: any; // passed in key value pairs of strings -> strings
     public suppressResizeListener: boolean; // whether a component's resize function is ignored. Applies to components which draw an SVG
-    public swimLaneOptions: {[key: number]: swimLaneOption} | null;  // mapping of swim lane number to information about that swimlane, including axis type
+    public swimLaneOptions: {[key: number]: SwimLaneOption} | null;  // mapping of swim lane number to information about that swimlane, including axis type
     public theme: string; // theme for styling chart, light or dark
     public timeFrame: any; // from and to to specify range of an event or state series
     public timestamp: any; //For components with a slider, this is the selected timestamp

--- a/src/UXClient/Models/ChartOptions.ts
+++ b/src/UXClient/Models/ChartOptions.ts
@@ -67,7 +67,7 @@ class ChartOptions {
     public onClick: (d3Event: any) => void; // for handling click, e.g. clicking on color picker
     public onInput: (searchText: string, event) => void; // for handling after input actions in ModelAutocomplete
     public onInstanceClick: (instance: any) => any;  // for model search, takes an instance and returns an object of context menu actions
-    public onHierarchyNodeClick: (hierarchyName: string, path: Array<hierarchyNodePath>) => any; // takes the path to that node when you click on a non-leaf/non-instance hierarchy node to trigger a custom context menu for fleet query etc.
+    public onHierarchyNodeClick: (hierarchyName: string, path: Array<HierarchyNodePath>) => any; // takes the path to that node when you click on a non-leaf/non-instance hierarchy node to trigger a custom context menu for fleet query etc.
     public onKeydown: (d3Event: any, awesompleteObject: any) => void;  // for handling keydown actions in ModelAutocomplete
     public onMarkersChange: (markers: Array<number>) => any; //triggered when a marker is either added or removed in the linechart
     public onMouseout: () => void;

--- a/src/UXClient/Models/ChartOptions.ts
+++ b/src/UXClient/Models/ChartOptions.ts
@@ -4,6 +4,7 @@ import Utils, { YAxisStates } from '../Utils';
 import { Strings } from './Strings';
 import { DefaultHierarchyNavigationOptions } from '../Constants/Constants';
 import { InterpolationFunctions } from '../Constants/Enums';
+import { HierarchyNodeOptions, HierarchyNodePath } from '../Components/HierarchyNavigation/HierarchyNavigation';
 
 // Interfaces
 interface SwimLaneOption {
@@ -11,11 +12,6 @@ interface SwimLaneOption {
     label?: string, 
     onClick?: (lane: number) => any, 
     collapseEvents?: string
-}
-
-interface HierarchyNodePath {
-    instanceFieldName: string,
-    instanceFieldValue: string
 }
 
 class ChartOptions {
@@ -67,7 +63,6 @@ class ChartOptions {
     public onClick: (d3Event: any) => void; // for handling click, e.g. clicking on color picker
     public onInput: (searchText: string, event) => void; // for handling after input actions in ModelAutocomplete
     public onInstanceClick: (instance: any) => any;  // for model search, takes an instance and returns an object of context menu actions
-    public onHierarchyNodeClick: (hierarchyName: string, path: Array<HierarchyNodePath>) => any; // takes the path to that node when you click on a non-leaf/non-instance hierarchy node to trigger a custom context menu for fleet query etc.
     public onKeydown: (d3Event: any, awesompleteObject: any) => void;  // for handling keydown actions in ModelAutocomplete
     public onMarkersChange: (markers: Array<number>) => any; //triggered when a marker is either added or removed in the linechart
     public onMouseout: () => void;
@@ -104,6 +99,7 @@ class ChartOptions {
     public hierarchyOptions: any; // hierarchy navigation related options for search api
     public onError: (titleKey, messageKey, xhr) => any;
     public timeSeriesIdProperties: Array<{name: string, type: any}>; // time series id properties to highlight and prioritize in events table
+    public hierarchyNodeOptions: (hierarchyName: string, path: Array<HierarchyNodePath>) => HierarchyNodeOptions | null; // hierarchy node related options including onHierarchyNodeClick and custom icon
 
     public stringsInstance: Strings = new Strings(); 
 
@@ -180,7 +176,6 @@ class ChartOptions {
         this.includeTimezones = this.mergeValue(chartOptionsObj, 'includeTimezones', true);
         this.availabilityLeftMargin = this.mergeValue(chartOptionsObj, 'availabilityLeftMargin', 60);
         this.onInstanceClick = this.mergeValue(chartOptionsObj, 'onInstanceClick', () => {return {}});
-        this.onHierarchyNodeClick = this.mergeValue(chartOptionsObj, 'onHierarchyNodeClick', () => {});
         this.interpolationFunction = this.getInterpolationFunction(this.mergeValue(chartOptionsObj, 'interpolationFunction', InterpolationFunctions.None));
         this.includeEnvelope = this.mergeValue(chartOptionsObj, 'includeEnvelope', false);
         this.canDownload = this.mergeValue(chartOptionsObj, 'canDownload', true);
@@ -215,6 +210,7 @@ class ChartOptions {
         this.onError = this.mergeValue(chartOptionsObj, 'onError', (titleKey, messageKey, xhr) => {});
         this.timeSeriesIdProperties = Utils.getValueOrDefault(chartOptionsObj, 'timeSeriesIdProperties', []);
         this.shouldSticky = this.mergeValue(chartOptionsObj, 'shouldSticky', true);
+        this.hierarchyNodeOptions = this.mergeValue(chartOptionsObj, 'hierarchyNodeOptions', null);
     }
 
     private mergeStrings (strings) {
@@ -279,7 +275,6 @@ class ChartOptions {
             includeTimezones: this.includeTimezones,
             availabilityLeftMargin: this.availabilityLeftMargin,
             onInstanceClick: this.onInstanceClick,
-            onHierarchyNodeClick: this.onHierarchyNodeClick,
             interpolationFunction: this.interpolationFunction,
             includeEnvelope: this.includeEnvelope,
             canDownload: this.canDownload,
@@ -314,7 +309,8 @@ class ChartOptions {
             onError: this.onError,
             labelSeriesWithMarker: this.labelSeriesWithMarker,
             timeSeriesIdProperties: this.timeSeriesIdProperties,
-            shouldSticky: this.shouldSticky
+            shouldSticky: this.shouldSticky,
+            hierarchyNodeOptions: this.hierarchyNodeOptions,
         }
     }
 }


### PR DESCRIPTION
- **hierarchyNodeOptions** added to ChartOptions, this was an static object in the first iteration but converted into a function which returns the options to be able to give user to decide on icon class and labels based on the params (hierarchy and instance fields), e.g. some hierarchy node can support fleet query while some just custom context menu
![image](https://user-images.githubusercontent.com/45217314/106027499-cb214380-607f-11eb-8685-861bd189aafd.png)
![image](https://user-images.githubusercontent.com/45217314/106027388-b3e25600-607f-11eb-93e8-c50491741f38.png)

- **\testcases\customContextMenuInHierarchy.html** added as a test page