### PR TITLE
User/niusoff/horizontal markers

### DIFF
--- a/pages/examples/testcases/swimLanes/horizontalMarkers.html
+++ b/pages/examples/testcases/swimLanes/horizontalMarkers.html
@@ -195,7 +195,7 @@
                             {dataType: 'numeric', searchSpan: searchSpan, onElementClick: onElementClick, swimLane: 5, horizontalMarkers: horizontalMarkers}]; 
 
                 var swimLaneOptions = {
-                    1: {yAxisType: 'shared', horizontalMarkers: [{color: '#000', value: 2.5}]},
+                    1: {yAxisType: 'shared', horizontalMarkers: [{color: '#000', value: 2.5}, {color: '#AAA', value: 2.8}]},
                     2: {yAxisType: 'overlap'},
                     3: {yAxisType: 'overlap'} 
                 }

--- a/pages/examples/testcases/swimLanes/horizontalMarkers.html
+++ b/pages/examples/testcases/swimLanes/horizontalMarkers.html
@@ -1,0 +1,231 @@
+
+<!DOCTYPE html> 
+<html>
+    <head>
+        <title>Horizontal markers</title>
+
+        <!-- boilerplate headers are injected with head.js, grab them from the live example header, or include a link to head.js -->
+        <script src="../../boilerplate/head.js"></script>
+    </head>
+    <body style="font-family: 'Segoe UI', sans-serif;">
+        <div id="chart1" style="width: 100%; height: 600px;"></div>
+        <div>
+            <label>Show series labels</label>
+            <input type="checkbox" id="showLabels" />
+        </div>
+        <div>
+            <h2>Lane selections:</h2>
+            <span>group 0: </span>
+            <select id='group0Select'>
+                <option selected>1</option>
+                <option>2</option>
+                <option>3</option>
+                <option>4</option>
+                <option>5</option>
+            </select>
+            <br/>
+            <span>group 1: </span>
+            <select id='group1Select'>
+                <option>1</option>
+                <option selected>2</option>
+                <option>3</option>
+                <option>4</option>
+                <option>5</option>
+            </select>
+            <br/>
+            <span>group 2: </span>
+            <select id='group2Select'>
+                <option>1</option>
+                <option>2</option>
+                <option selected>3</option>
+                <option>4</option>
+                <option>5</option>
+            </select>
+            <br/>
+            <span>group 3: </span>
+            <select id='group3Select'>
+                <option>1</option>
+                <option>2</option>
+                <option>3</option>
+                <option selected>4</option>
+                <option>5</option>
+            </select>
+            <br/>
+            <span>group 4: </span>
+            <select id='group4Select'>
+                <option>1</option>
+                <option>2</option>
+                <option>3</option>
+                <option>4</option>
+                <option selected>5</option>
+            </select>
+        </div>
+        <script>
+            window.onload = function() {
+                // create fake data in the shape our charts expect
+                let numberOfBuckets = 120;
+                var data = [];
+                var from = new Date(Math.floor((new Date()).valueOf() / (1000*60 * 60)) * (1000*60 * 60));
+                var to;
+                for(var i = 0; i < 3; i++){
+                    var lines = {};
+                    data.push({[`Factory${i}`]: lines});
+                    var values = {};
+                    lines[``] = values;
+                    for(var k = 0; k < numberOfBuckets; k++){
+                        if (i % 2 === 0) {
+                            // if(!(k%2 && k%3)){  // if check is to create some sparseness in the data
+                                var to = new Date(from.valueOf() + 1000*60*k);
+                                var val = Math.random() + (j !== 4 ? 2 : 0);
+                                var val2 = Math.random();
+                                var val3 = Math.random();
+                                var val4 = Math.random();
+                                values[to.toISOString()] = {avg: val, x: val2, y: val3, r: val4};
+                            // }
+                        } else {
+                            var val1 = Math.random();
+                            if (val1 < .5) {
+                                val1 = 1;
+                            }
+                            var val2 = (1 - val1) / 2;
+                            var val3 = (1 - val1) / 2;
+                            var to = new Date(from.valueOf() + 1000*60*k);
+                            if(Math.random() < .2)
+                                values[to.toISOString()] = {state1: val1, state2: val2, state3: val3};
+                            else
+                                values[to.toISOString()] = null;
+                        }
+                    } 
+                }
+                var random1Through10 = function () {
+                    return Math.ceil(Math.random() * 10);
+                }
+
+                var lines = {};
+                var events = {};
+                data.push({[`Factory3`]: events});
+                data.push({[`Factory 4`]: lines})
+                for(var j = 0; j < 1; j++){
+                        var values = {};
+                        lines[`Station${j}`] = values;
+                        events[`Station${j}`] = {};
+                        for(var k = 0; k < numberOfBuckets; k++){
+                            var val1 = Math.random(); 
+                            var val2 = 1- val1;
+                            var val3 = 0;
+                            if (j === 1) {
+                                val1 = 0;
+                                val2 = 1;
+                                val3 = 0;
+                            } 
+                            if (j === 2) {
+                                val1 = 0;
+                                val2 = 0;
+                                val3 = 1;
+                            }
+                            let previousTo = to;
+                            var toLocal = new Date(from.valueOf() + 1000*60*k);
+                            values[toLocal.toISOString()] = {state1: val1, state2: val2, state3: val3};
+
+                            if (Math.random() > .8) {
+                                let goodOrBad = Math.random() > .5;
+                                let goodAndBad = Math.random() > .8;
+                                let localEvent = {};
+                                events[`Station${j}`][toLocal.toISOString()] = localEvent;
+                                localEvent[goodOrBad ? 'goodEvent' : 'badEvent'] = (goodOrBad ? random1Through10() : random1Through10());
+                                if (goodAndBad) {
+                                    localEvent[goodOrBad ? 'badEvent' : 'goodEvent'] = (!goodOrBad ? random1Through10() : random1Through10());                                    
+                                }
+                                if (Math.random() > .7) {
+                                    localEvent['neutral Event'] = 'neutral message';                                    
+                                }
+                                
+                            }
+                            to = toLocal;
+                    }
+                }
+
+                let searchSpan = {
+                    from: from.toISOString(),
+                    to: new Date(to.valueOf() + 45 * 1000).toISOString(),
+                    bucketSize: '1m'
+                }
+
+
+                // render the data in a chart
+                var tsiClient = new TsiClient();
+                var lineChart = new tsiClient.ux.LineChart(document.getElementById('chart1'));
+                let valueMapping = {
+                    state1: {
+                        color: '#F2C80F'
+                    }, 
+                    state2: {
+                        color: '#FD625E'
+                    },
+                    state3: {
+                        color:'#3599B8'
+                    }
+                }
+                let eventValueMapping = {
+                    badEvent: {
+                        color: 'red'
+                    },
+                    goodEvent: {
+                        color: 'blue'
+                    }
+                }
+                eventValueMapping['neutral Event'] =  { color: 'purple' };
+
+                var onElementClick = function (aggKey, splitBy, ts, measures) {
+                    console.log(aggKey, splitBy, ts, measures);
+                }
+
+                var horizontalMarkers = [
+                    {color: 'blue', value: 0.1},
+                    {color: 'grey', value: 0.25},
+                    {color: 'grey', value: 0.6},
+                    {color: 'grey', value: 0.750},
+                    {color: 'red', value: 0.9},
+                ]
+
+                var chartDataOptions = [{dataType: 'numeric', searchSpan: searchSpan, swimLane: 1}, 
+                            {dataType: 'numeric', searchSpan: searchSpan, swimLane: 2}, 
+                            {dataType: 'categorical', valueMapping: valueMapping, height: 50, searchSpan: searchSpan, onElementClick: onElementClick, swimLane: 3},
+                            {dataType: 'events', valueMapping: eventValueMapping, height: 30, eventElementType: 'teardrop', onElementClick: onElementClick, swimLane: 4},
+                            {dataType: 'numeric', searchSpan: searchSpan, onElementClick: onElementClick, swimLane: 5, horizontalMarkers: horizontalMarkers}]; 
+
+                var swimLaneOptions = {
+                    1: {yAxisType: 'shared', horizontalMarkers: [{color: '#000', value: 2.5}]},
+                    2: {yAxisType: 'overlap'},
+                    3: {yAxisType: 'overlap'} 
+                }
+
+                var chartOptions = {theme: 'light', tooltip: 'true', swimLaneOptions: swimLaneOptions, labelSeriesWithMarker: false};
+
+                var renderLinechart = function () {
+                    lineChart.render(data, chartOptions, chartDataOptions);
+                }
+
+                renderLinechart();
+
+                function changeSwimLaneAndRender (aggGroup, newSwimLane) {
+                    chartDataOptions[aggGroup].swimLane = newSwimLane;
+                    renderLinechart();
+                }
+
+                function changeShowSeriesLabelsAndRender (shouldChange) {
+                    console.log(shouldChange);
+                    chartOptions.labelSeriesWithMarker = !chartOptions.labelSeriesWithMarker;
+                    renderLinechart();
+                }
+
+                document.getElementById(`group0Select`).onchange = function(evt) { changeSwimLaneAndRender(0, Number(evt.target.value))};
+                document.getElementById(`group1Select`).onchange = function(evt) { changeSwimLaneAndRender(1, Number(evt.target.value))};
+                document.getElementById(`group2Select`).onchange = function(evt) { changeSwimLaneAndRender(2, Number(evt.target.value))};
+                document.getElementById(`group3Select`).onchange = function(evt) { changeSwimLaneAndRender(3, Number(evt.target.value))};
+                document.getElementById(`group4Select`).onchange = function(evt) { changeSwimLaneAndRender(4, Number(evt.target.value))};
+                document.getElementById('showLabels').onclick = function(evt) { changeShowSeriesLabelsAndRender(evt.target.checked)}
+            };
+        </script>
+    </body>
+</html>

--- a/src/UXClient/Components/LineChart/LineChart.scss
+++ b/src/UXClient/Components/LineChart/LineChart.scss
@@ -269,6 +269,15 @@
             }
         }
     }
+
+    .tsi-horizontalMarkerLine {
+        stroke-dasharray: 2,2;
+    }
+
+    .tsi-horizontalMarkerText {
+        font-style: italic;
+        text-anchor: end;
+    }
     
     &.tsi-dark{
         $grays: grays('dark');

--- a/src/UXClient/Components/LineChart/LineChart.ts
+++ b/src/UXClient/Components/LineChart/LineChart.ts
@@ -1268,7 +1268,12 @@ class LineChart extends TemporalXAxisComponent {
             this.aggregateExpressionOptions.forEach((aEO) => {
                 aEO.swimLane = 0;
             });
-            this.chartOptions.swimLaneOptions = {0: {yAxisType: this.chartOptions.yAxisState}};
+            // consolidate horizontal markers
+            const horizontalMarkers = [];
+            Object.values(this.chartOptions.swimLaneOptions).forEach((lane) => {
+                horizontalMarkers.push(...lane.horizontalMarkers);
+            });
+            this.chartOptions.swimLaneOptions = {0: {yAxisType: this.chartOptions.yAxisState, horizontalMarkers: horizontalMarkers}};
         } else {
             let minimumPresentSwimLane = this.aggregateExpressionOptions.reduce((currMin, aEO) => {
                 return Math.max(aEO.swimLane, currMin); 
@@ -1319,7 +1324,7 @@ class LineChart extends TemporalXAxisComponent {
             });
         }
 
-        if (this.chartOptions.yAxisState === YAxisStates.Stacked) {
+        if (this.chartOptions.yAxisState !== YAxisStates.Overlap) {
             Object.keys(this.chartOptions.swimLaneOptions).forEach((swimlaneNumber) => {
                 const swimlaneOptions = this.chartOptions.swimLaneOptions[swimlaneNumber];
                 swimlaneOptions.horizontalMarkers?.forEach((horizontalMarkerParams: HorizontalMarker) => {

--- a/src/UXClient/Models/ChartDataOptions.ts
+++ b/src/UXClient/Models/ChartDataOptions.ts
@@ -1,5 +1,6 @@
 import { InterpolationFunctions, DataTypes, EventElementTypes } from "../Constants/Enums";
 import Utils from "../Utils";
+import { HorizontalMarker } from '../Utils/Interfaces'
 
 const DEFAULT_HEIGHT = 40;
 // Represents an expression that is suitable for use as the expression options parameter in a chart component
@@ -35,6 +36,7 @@ class ChartDataOptions {
     public image: string;
     public isRawData: boolean;
     public isVariableAliasShownOnTooltip: boolean;
+    public horizontalMarkers: Array<HorizontalMarker>;
 
     constructor (optionsObject: Object){
         this.searchSpan = Utils.getValueOrDefault(optionsObject, 'searchSpan');
@@ -67,6 +69,7 @@ class ChartDataOptions {
         this.startAt = Utils.getValueOrDefault(optionsObject, 'startAt', null);
         this.isRawData = Utils.getValueOrDefault(optionsObject, 'isRawData', false);
         this.isVariableAliasShownOnTooltip = Utils.getValueOrDefault(optionsObject, 'isVariableAliasShownOnTooltip', true);
+        this.horizontalMarkers = Utils.getValueOrDefault(optionsObject, 'horizontalMarkers', []);
     }
 }
 export {ChartDataOptions}

--- a/src/UXClient/Models/ChartOptions.ts
+++ b/src/UXClient/Models/ChartOptions.ts
@@ -3,13 +3,15 @@ import Utils from '../Utils';
 import { Strings } from './Strings';
 import { DefaultHierarchyNavigationOptions } from '../Constants/Constants';
 import { InterpolationFunctions, YAxisStates } from '../Constants/Enums';
+import { HorizontalMarker } from '../Utils/Interfaces';
 
 // Interfaces
 interface swimLaneOption {
     yAxisType: YAxisStates, 
     label?: string, 
     onClick?: (lane: number) => any, 
-    collapseEvents?: string
+    collapseEvents?: string,
+    horizontalMarkers?: Array<HorizontalMarker>
 }
 
 class ChartOptions {

--- a/src/UXClient/Utils/Interfaces.ts
+++ b/src/UXClient/Utils/Interfaces.ts
@@ -1,0 +1,4 @@
+export interface HorizontalMarker { 
+    color: string,
+    value: number
+}


### PR DESCRIPTION
Added the concept of *horizontal markers*, which are defined by a color and a value, and are represented by a dotted line and a label in the line chart component.

Markers are passed in either as a property of a swimlane, through swimlaneOptions in chartOptions, e.g.: 
`swimLaneOptions = {1: {yAxisType: 'shared', horizontalMarkers: [{color: '#000', value: 2.5}`
or through chartDataOptions 
`chartDataOptions = [{..., horizontalMarkers: [{color: 'blue', value: 0.1}, {color: 'grey', value: 0.25}], ...]`

Some non-eplicit behavior of horizontal markers are...
- Horizontal markers are NOT rendered when global y axis state is overlap, or if they exist in a swimlane where the y axis state is overlap
- all horizontal markers passed through swimlanes are displayed when the global y axis state is shared
- horizontal markers with values outside the domain of the swimlane they exist in are NOT rendered

![image](https://user-images.githubusercontent.com/35545215/134422709-ea2e2105-67b1-4714-a417-b145953463fe.png)

