### PR TITLE
Update package.json to include license information

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "description": "",
     "version": "1.4.13",
     "types": "tsiclient.d.ts",
+    "license": "MIT",
     "repository": {
         "type": "git",
         "url": "https://github.com/Microsoft/tsiclient"


### PR DESCRIPTION
Adding `"license": "MIT"` to the package.json. This should allow the [ClearlyDefined](https://clearlydefined.io) tooling to automatically pick up the license info (https://github.com/clearlydefined/service/blob/master/docs/determining-declared-license.md)