### PR TITLE
simplify accessible name of date selector dialog

### DIFF
--- a/src/UXClient/Interfaces/DateTimeButton.ts
+++ b/src/UXClient/Interfaces/DateTimeButton.ts
@@ -35,7 +35,7 @@ class DateTimeButton extends ChartComponent {
         if (!this.dateTimePickerContainer) {
             this.dateTimePickerContainer = dateTimeContainer.append('div').classed('tsi-dateTimePickerContainer', true)
                                             .attr('role', 'dialog')
-                                            .attr('aria-label', this.getString('a time selection control dialog'));
+                                            .attr('aria-label', this.getString('date selector'));
             this.dateTimePickerContainer.style('display', 'none');
         }
         super.themify(d3.select(this.renderTarget), this.chartOptions.theme);        


### PR DESCRIPTION
this PR simply changes the current dialog name from "a time selection control dialog" to a much more concise string of "date selector".  
The word "dialog" will already be announced by screen readers per this component's role, so we don't need it as part of the name.