### PR TITLE
Turn error message container into a live region

### DIFF
--- a/src/UXClient/Components/DateTimePicker/DateTimePicker.ts
+++ b/src/UXClient/Components/DateTimePicker/DateTimePicker.ts
@@ -190,7 +190,7 @@ class DateTimePicker extends ChartComponent{
         this.setFromMillis(fromMillis);
         this.setToMillis(toMillis); 
         
-        this.targetElement.append("div").classed("tsi-errorMessageContainer", true);
+        this.targetElement.append("div").classed("tsi-errorMessageContainer", true).attr('aria-live', 'assertive');
         this.createTimePicker();
         this.createCalendar();
         this.calendarPicker.draw();


### PR DESCRIPTION
presently if someone were to cause a validation error with one of the date picker fields, error messages will appear at the bottom of the dialog.  However, as these messages are not presently injected into a live region, these error messages will not be exposed to screen reader users - failing wcag 4.1.3 Status Messages.

This PR adds an `aria-live=assertive` to the `tsi-errorMessageContainer` which will help ensure that these messages are announced when they dynamically appear.