### PR TITLE
Accessbility | Linechart Screen reader issue fix

### DIFF
--- a/src/UXClient/Components/LineChart/LineChart.ts
+++ b/src/UXClient/Components/LineChart/LineChart.ts
@@ -165,6 +165,8 @@ class LineChart extends TemporalXAxisComponent {
         this.targetElement.selectAll(".tsi-markerInstructions").remove();
         this.targetElement.append("div")
             .classed("tsi-markerInstructions", true)
+            .attr('role', 'alert')
+            .attr('aria-live', 'assertive')
             .text(this.getString("Click to drop marker") + "," + this.getString("drag to reposition") + "."); 
     }
 


### PR DESCRIPTION
[Bug 10549303]: [Screen reader - Analytics-Ellipsis_Status Messages]: NVDA/Narrator is not announcing 'Click to drop marker, drag to reposition' alert message which is available on selecting 'Drop a marker' list item.