### PR TITLE
Bumping version to fix published package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "tsiclient",
-    "version": "1.4.21",
+    "version": "1.4.22",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "tsiclient",
     "main": "tsiclient.js",
     "description": "",
-    "version": "1.4.21",
+    "version": "1.4.22",
     "types": "tsiclient.d.ts",
     "repository": {
         "type": "git",


### PR DESCRIPTION
Package published in 1.4.21 did not include built javascript files. The package was re-published with version 1.4.22. 