### PR TITLE
Enable option to not hide chart control panel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "tsiclient",
-    "version": "1.4.23",
+    "version": "1.4.24",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "tsiclient",
     "main": "tsiclient.js",
     "description": "",
-    "version": "1.4.23",
+    "version": "1.4.24",
     "types": "tsiclient.d.ts",
     "repository": {
         "type": "git",

--- a/src/UXClient/Components/AvailabilityChart/AvailabilityChart.ts
+++ b/src/UXClient/Components/AvailabilityChart/AvailabilityChart.ts
@@ -196,7 +196,6 @@ class AvailabilityChart extends ChartComponent{
         this.chartOptions.brushClearable = false;
         this.chartOptions.minBrushWidth = 1;
         this.chartOptions.brushHandlesVisible = true;
-        this.chartOptions.hideChartControlPanel = true;
 
         let brushMoveAction = this.chartOptions.brushMoveAction;
 


### PR DESCRIPTION
Currently the availability chart always hides the chart control panel, this PR removes the restriction and allows the consumer to hide or not hide it. This fixes an accessibility issue on the availability chart by allowing the user to display the chart data in a grid.