### PR TITLE
Screen reader should only announce h2 in tooltip for charts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "tsiclient",
-    "version": "1.4.26",
+    "version": "1.4.27",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "tsiclient",
     "main": "tsiclient.js",
     "description": "",
-    "version": "1.4.26",
+    "version": "1.4.27",
     "types": "tsiclient.d.ts",
     "repository": {
         "type": "git",

--- a/src/UXClient/Interfaces/Component.ts
+++ b/src/UXClient/Interfaces/Component.ts
@@ -45,13 +45,13 @@ class Component {
 		Utils.appendFormattedElementsFromString(title, d.aggregateName);
 
 		if (d.splitBy && d.splitBy != ""){
-			let splitBy = group.append('h4')
+			let splitBy = group.append('p')
 				.attr('class', 'tsi-tooltipSeriesName tsi-tooltipSubtitle');
 			Utils.appendFormattedElementsFromString(splitBy, d.splitBy);
 		}
 		
 		if (cDO.variableAlias && cDO.isVariableAliasShownOnTooltip){
-			group.append('h4')
+			group.append('p')
 				.text(cDO.variableAlias)
 				.attr('class', 'tsi-tooltipVariableAlias tsi-tooltipSubtitle');
 		}


### PR DESCRIPTION
Convert `h4`s to `p`s so they don't get announced when using NVDA screen reader in scan mode for headings